### PR TITLE
Add Pii Info to datasets

### DIFF
--- a/docs/source/redact/datasets.rst
+++ b/docs/source/redact/datasets.rst
@@ -83,3 +83,8 @@ To download a specific file in a dataset that you fetch by name:
     file_bytes = file.download()
     with open('<file name>', 'wb') as f:
         f.write(file_bytes)
+
+Viewing the pii information of a dataset
+--------------------------------------
+
+To view the PII information of a dataset, call the **pii_info** function. If information has not yet been fetched, the function will fetch the information from the server.

--- a/tonic_textual/classes/common_api_responses/base_file.py
+++ b/tonic_textual/classes/common_api_responses/base_file.py
@@ -20,8 +20,6 @@ class BaseFile(object):
         self.wordCount = response["wordCount"]
         self.characterCount = response["characterCount"]
         self.redactedWordCount = response["redactedWordCount"]
-        self.piiTypes = response["piiTypes"]
-        self.piiTypeExamples = response["piiTypeExamples"]
         self.createdDate = response["createdDate"]
         self.lastModifiedDate = response["lastModifiedDate"]
         self.fileHash = response["fileHash"]

--- a/tonic_textual/classes/dataset.py
+++ b/tonic_textual/classes/dataset.py
@@ -10,6 +10,7 @@ import requests.exceptions
 import requests
 
 from tonic_textual.classes.common_api_responses.label_custom_list import LabelCustomList
+from tonic_textual.classes.pii_info import DatasetPiiInfo
 from tonic_textual.classes.enums.file_redaction_policies import docx_image_policy, docx_comment_policy, pdf_signature_policy
 from tonic_textual.classes.tonic_exception import (
     DatasetFileMatchesExistingFile,
@@ -113,6 +114,15 @@ class Dataset:
             self.num_columns = max([f.num_columns for f in self.files])
         else:
             self.num_columns = None
+        self._pii_info = None
+
+    @property
+    def pii_info(self):
+        if self._pii_info is None:
+            with requests.Session() as session:
+                data = self.client.http_get(f"/api/dataset/{self.id}/pii_info", session=session)
+                self._pii_info = DatasetPiiInfo(data, self.files)
+        return self._pii_info
 
     def edit(
         self,

--- a/tonic_textual/classes/pii_info.py
+++ b/tonic_textual/classes/pii_info.py
@@ -1,0 +1,46 @@
+from typing import Dict, List
+
+from tonic_textual.classes.datasetfile import DatasetFile
+
+
+class PiiTextExample:
+    def __init__(self, data: Dict) -> None:
+        self.text: str = data['text']
+        self.start_index: int = data['startIndex']
+        self.end_index: int = data['endIndex']
+
+    def describe(self) -> Dict:
+        return {
+            'text': self.text,
+            'start_index': self.start_index,
+            'end_index': self.end_index
+        }
+
+
+class DatasetFilePiiInfo:
+    def __init__(self, data: Dict, name: str) -> None:
+        self.name = name
+        self.pii_type_counts: Dict[str, int] = data['piiTypeCounts']
+        self.pii_text_examples: Dict[str, List[PiiTextExample]] = {
+            k: [PiiTextExample(e) for e in v] for k, v in data['piiTextExamples'].items()
+        }
+
+    def describe(self) -> Dict:
+        return {
+            'name': self.name,
+            'pii_type_counts': self.pii_type_counts,
+            'pii_text_examples': {k: [e.describe() for e in v] for k, v in self.pii_text_examples.items()}
+        }
+
+
+class DatasetPiiInfo:
+    def __init__(self, data: Dict, files: List[DatasetFile]) -> None:
+        self.file_pii_info: Dict[str, DatasetFilePiiInfo] = {}
+        for k, v in data['filePiiInfo'].items():
+            file_name = next(file.name for file in files if file.id == k)
+            self.file_pii_info[k] = DatasetFilePiiInfo(v, file_name)
+
+    def describe(self) -> Dict:
+        return {
+            'file_pii_info': {k: v.describe() for k, v in self.file_pii_info.items()}
+        }


### PR DESCRIPTION
To test:
```
from tonic_textual.redact_api import TonicTextual

textual = TonicTextual("<host>", "<api-key>")
ds = textual.get_dataset("test")
print(ds.pii_info.describe())
"""
{
  "file_pii_info": {
    "7bae8b44-b841-f033-94ef-91a7a8941469": {
      "name": "sales_report.docx",
      "pii_type_counts": {
        "DATE_TIME": 7,
        "NUMERIC_VALUE": 1,
        "NAME_GIVEN": 8,
        "NAME_FAMILY": 7,
        "HEALTHCARE_ID": 3,
        "MONEY": 7,
        "LOCATION_ZIP": 2
      },
      "pii_text_examples": {
        "DATE_TIME": [
          {
            "text": "The chart displays monthly sales performance from January through December. Each bar represents individual ",
            "start_index": 50,
            "end_index": 57
          },
          {
            "text": "ys monthly sales performance from January through December. Each bar represents individual sales by three ke",
            "start_index": 50,
            "end_index": 58
          }
          # ...
        ],
        "NAME_FAMILY": [
          # ...
        ],
        "HEALTHCARE_ID": [
          # ...
        ],
        "MONEY": [
          # ...
        ],
        "LOCATION_ZIP": [
          # ...
        ]
      }
    }
  }
}
"""
```