### PR TITLE
Install pyaudioop on Python 3.13+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pytest-regressions = "^2.7.0"
 pandas = "^2.2.3"
 pymupdf = "^1.25.5"
 pydub = "0.25.1"
+pyaudioop = { version = "^1.0.0", python = ">=3.13" }
 boto3 = "^1.38.20"
 azure-storage-blob = "^12.25.1"
 


### PR DESCRIPTION
`pydub` relies on `audioop`, which was deprecated in python 3.13. Here we fallback to `pyaudioop` to fix the error thrown when the import fails:
```
____________________ test_redact_audio_file_does_not_throw _____________________
    from __future__ import division
    
    import json
    import os
    import re
    import sys
    from subprocess import Popen, PIPE
    from math import log, ceil
    from tempfile import TemporaryFile
    from warnings import warn
    from functools import wraps
    
    try:
>       import audioop
E       ModuleNotFoundError: No module named 'audioop'
/home/runner/.cache/pypoetry/virtualenvs/tonic-***-lEElrt3U-py3.13/lib/python3.13/site-packages/pydub/utils.py:14: ModuleNotFoundError
During handling of the above exception, another exception occurred:
self = <tonic_***.audio_api.TextualAudio object at 0x7f69cf275810>
audio_file_path = '/home/runner/work/solar/solar/python_sdk/tests/resources/banking_customer_support.mp3'
output_file_path = 'output.mp3'
generator_default = <PiiState.Redaction: 'Redaction'>, generator_config = {}
label_block_lists = None, label_allow_lists = None, custom_entities = None
before_beep_buffer = 250.0, after_beep_buffer = 250.0
    def redact_audio_file(
        self,
        audio_file_path: str,
        output_file_path: str,
        generator_default: PiiState = PiiState.Redaction,
        generator_config: Dict[str, PiiState] = dict(),
        label_block_lists: Optional[Dict[str, List[str]]] = None,
        label_allow_lists: Optional[Dict[str, List[str]]] = None,
        custom_entities: Optional[List[str]] = None,
        before_beep_buffer: float = 250.0,
        after_beep_buffer: float = 250.0
    ):
        """Generates a redacted audio file by identifying and removing sensitive audio segments. Note that calling this method requires that pydub be installed in addition to the tonic_*** library.  Additionally, you'll need to ensure that your install of ffmpeg has the necessary codec support for your file type.
    
        Parameters
        ----------
        audio_file_path : str
            The path to the input audio file.
            Supported file types are wav, mp3, ogg, flv, wma, aac, and others. See
            https://github.com/jiaaro/pydub for complete information on file types
            supported.
    
        output_file_path : str
            The path to save the redacted output file. The output file path specifies
            the audio file type that the output is written as via it's extension.
            Supported file types are wav, mp3, ogg, flv, wma, and aac. See
            https://github.com/jiaaro/pydub for complete information on file types
            supported.
    
        generator_default: PiiState = PiiState.Redaction
            The default redaction used for types that are not specified in
            generator_config. Value must be one of "Redaction", "Synthesis", or
            "Off".
    
        generator_config: Dict[str, PiiState]
            A dictionary of sensitive data entities. For each entity, indicates
            whether to redact, synthesize, or ignore it. Values must be one of
            "Redaction", "Synthesis", or "Off".
    
        label_block_lists: Optional[Dict[str, List[str]]]
            A dictionary of (entity type, ignored values). When a value for an
            entity type matches a listed regular expression, the value is
            ignored and is not redacted or synthesized.
    
        label_allow_lists: Optional[Dict[str, List[str]]]
            A dictionary of (entity type, additional values). When a piece of
            text matches a listed regular expression, the text is marked as the
            entity type and is included in the redaction or synthesis.
    
        custom_entities: Optional[List[str]]
            A list of custom entity type identifiers to include. Each custom
            entity type included here may also be included in the generator
            config. Custom entity types will respect generator defaults if they
            are not specified in the generator config.
    
        before_beep_buffer : float, optional
            Buffer time (in milliseconds) to include before redaction interval
            (default is 250.0).
    
        after_beep_buffer : float, optional
            Buffer time (in milliseconds) to include after redaction interval
            (default is 250.0).
    
        Returns
        -------
        str
            The path to the redacted output audio file.
        """
        try:
>           from pydub import AudioSegment
../tonic_***/audio_api.py:298: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/runner/.cache/pypoetry/virtualenvs/tonic-***-lEElrt3U-py3.13/lib/python3.13/site-packages/pydub/__init__.py:1: in <module>
    from .audio_segment import AudioSegment
/home/runner/.cache/pypoetry/virtualenvs/tonic-***-lEElrt3U-py3.13/lib/python3.13/site-packages/pydub/audio_segment.py:11: in <module>
    from .utils import mediainfo_json, fsdecode
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
    from __future__ import division
    
    import json
    import os
    import re
    import sys
    from subprocess import Popen, PIPE
    from math import log, ceil
    from tempfile import TemporaryFile
    from warnings import warn
    from functools import wraps
    
    try:
        import audioop
    except ImportError:
>       import pyaudioop as audioop
E       ModuleNotFoundError: No module named 'pyaudioop'
/home/runner/.cache/pypoetry/virtualenvs/tonic-***-lEElrt3U-py3.13/lib/python3.13/site-packages/pydub/utils.py:16: ModuleNotFoundError
During handling of the above exception, another exception occurred:
***_audio = <tonic_***.audio_api.TextualAudio object at 0x7f69cf275810>
    def test_redact_audio_file_does_not_throw(***_audio):
        path = get_resource_path('banking_customer_support.mp3')
>       ***_audio.redact_audio_file(path, 'output.mp3')
tests/audio_tests/test_redact_audio_file.py:6: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <tonic_***.audio_api.TextualAudio object at 0x7f69cf275810>
audio_file_path = '/home/runner/work/solar/solar/python_sdk/tests/resources/banking_customer_support.mp3'
output_file_path = 'output.mp3'
generator_default = <PiiState.Redaction: 'Redaction'>, generator_config = {}
label_block_lists = None, label_allow_lists = None, custom_entities = None
before_beep_buffer = 250.0, after_beep_buffer = 250.0
    def redact_audio_file(
        self,
        audio_file_path: str,
        output_file_path: str,
        generator_default: PiiState = PiiState.Redaction,
        generator_config: Dict[str, PiiState] = dict(),
        label_block_lists: Optional[Dict[str, List[str]]] = None,
        label_allow_lists: Optional[Dict[str, List[str]]] = None,
        custom_entities: Optional[List[str]] = None,
        before_beep_buffer: float = 250.0,
        after_beep_buffer: float = 250.0
    ):
        """Generates a redacted audio file by identifying and removing sensitive audio segments. Note that calling this method requires that pydub be installed in addition to the tonic_*** library.  Additionally, you'll need to ensure that your install of ffmpeg has the necessary codec support for your file type.
    
        Parameters
        ----------
        audio_file_path : str
            The path to the input audio file.
            Supported file types are wav, mp3, ogg, flv, wma, aac, and others. See
            https://github.com/jiaaro/pydub for complete information on file types
            supported.
    
        output_file_path : str
            The path to save the redacted output file. The output file path specifies
            the audio file type that the output is written as via it's extension.
            Supported file types are wav, mp3, ogg, flv, wma, and aac. See
            https://github.com/jiaaro/pydub for complete information on file types
            supported.
    
        generator_default: PiiState = PiiState.Redaction
            The default redaction used for types that are not specified in
            generator_config. Value must be one of "Redaction", "Synthesis", or
            "Off".
    
        generator_config: Dict[str, PiiState]
            A dictionary of sensitive data entities. For each entity, indicates
            whether to redact, synthesize, or ignore it. Values must be one of
            "Redaction", "Synthesis", or "Off".
    
        label_block_lists: Optional[Dict[str, List[str]]]
            A dictionary of (entity type, ignored values). When a value for an
            entity type matches a listed regular expression, the value is
            ignored and is not redacted or synthesized.
    
        label_allow_lists: Optional[Dict[str, List[str]]]
            A dictionary of (entity type, additional values). When a piece of
            text matches a listed regular expression, the text is marked as the
            entity type and is included in the redaction or synthesis.
    
        custom_entities: Optional[List[str]]
            A list of custom entity type identifiers to include. Each custom
            entity type included here may also be included in the generator
            config. Custom entity types will respect generator defaults if they
            are not specified in the generator config.
    
        before_beep_buffer : float, optional
            Buffer time (in milliseconds) to include before redaction interval
            (default is 250.0).
    
        after_beep_buffer : float, optional
            Buffer time (in milliseconds) to include after redaction interval
            (default is 250.0).
    
        Returns
        -------
        str
            The path to the redacted output audio file.
        """
        try:
            from pydub import AudioSegment
            from tonic_***.helpers.redact_audio_file_helper import (
                get_intervals_to_redact,
                redact_audio_segment
            )
        except ImportError as _:
>           raise ImportError(
                "The pydub Python package is required to redact audio files. To use this method install it via pip install pydub."
            )
E           ImportError: The pydub Python package is required to redact audio files. To use this method install it via pip install pydub.
../tonic_***/audio_api.py:304: ImportError
```