### PR TITLE
Fix incorporating epsilon

### DIFF
--- a/tonic_textual/helpers/redact_audio_file_helper.py
+++ b/tonic_textual/helpers/redact_audio_file_helper.py
@@ -179,8 +179,8 @@ def redact_audio_segment(
     """
     for (start, end) in intervals_to_redact:
         # convert seconds to milliseconds
-        start_time = (start - before_eps)
-        end_time = (end + after_eps)
+        start_time = max((start - before_eps), 0)
+        end_time = min((end + after_eps), len(audio))
         segment = audio[start_time:end_time]
         average_volume = segment.dBFS
         beep = Sine(1000).to_audio_segment(


### PR DESCRIPTION
When `start_time = (start - before_eps)` is less than 0, then the beep is not incorporated into the audio. This PR fixes this bug for `start_time` and `end_time` making them be at minimum 0 and at maximum the length of the audio respectively.