### PR TITLE
Add new generator configuration fields

### DIFF
--- a/docs/source/redact/generator_metadata.rst
+++ b/docs/source/redact/generator_metadata.rst
@@ -132,6 +132,7 @@ Date and time synthesis
 * ``scramble_unrecognized_dates`` (bool, default ``True``) -- When ``True``, dates that Textual cannot parse into a standard format are scrambled.
 * ``additional_date_formats`` (list of str, default ``[]``) -- Additional date format patterns that Textual should recognize. Uses Python ``strftime``/``strptime`` format codes.
 * ``apply_constant_shift_to_document`` (bool, default ``False``) -- When ``True``, all dates within the same document are shifted by the same random offset. This preserves the relative time differences between dates.
+* ``use_clear_date_and_passthrough_or_group_year_generator`` (bool, default ``False``) -- When ``True``, sets the date to January 1st and if the year is less than 90 years ago, passes through the year. Otherwise, sets the year to the current year minus 90.
 * ``metadata`` (:class:`~tonic_textual.classes.generator_metadata.timestamp_shift_metadata.TimestampShiftMetadata`) -- Controls the date shift range. By default, dates shift by -7 to +7 days.
 
 TimestampShiftMetadata
@@ -170,6 +171,7 @@ Person age synthesis
 :class:`~tonic_textual.classes.generator_metadata.person_age_generator_metadata.PersonAgeGeneratorMetadata` controls how synthesized ages are generated. Use it with the ``PERSON_AGE`` entity type.
 
 * ``scramble_unrecognized_dates`` (bool, default ``True``) -- When ``True``, dates that Textual cannot parse are scrambled.
+* ``use_passthrough_or_group_age_generator`` (bool, default ``False``) -- When ``True``, passes through ages 89 or under. Changes other ages to ``"90+"``.
 * ``metadata`` (:class:`~tonic_textual.classes.generator_metadata.age_shift_metadata.AgeShiftMetadata`) -- Controls the age shift amount. By default, ages shift by 7 years.
 
 AgeShiftMetadata
@@ -205,6 +207,8 @@ Address synthesis (HIPAA)
 * ``use_non_hipaa_address_generator`` (bool, default ``False``) -- When ``True``, uses a non-HIPAA-compliant address generator that might produce more realistic addresses, but does not guarantee HIPAA Safe Harbor compliance.
 * ``replace_truncated_zeros_in_zip_code`` (bool, default ``True``) -- When ``True``, for ZIP codes that are truncated to three digits (per HIPAA Safe Harbor), the removed digits are replaced with zeros.
 * ``realistic_synthetic_values`` (bool, default ``True``) -- When ``True``, generates realistic-looking synthetic address values.
+* ``use_three_digit_zips`` (bool, default ``False``) -- When ``True``, zip codes are always truncated to three digits.
+* ``replace_foreign_zip_codes_with_zeros`` (bool, default ``False``) -- When ``True``, foreign zip codes become all zeros.
 
 .. code-block:: python
 

--- a/docs/source/redact/generator_metadata.rst
+++ b/docs/source/redact/generator_metadata.rst
@@ -34,9 +34,10 @@ When you use ``generator_config`` to set an entity type to ``Synthesis``, Textua
 Common parameters
 -----------------
 
-All metadata classes inherit from ``BaseMetadata`` and share the following parameter:
+All metadata classes inherit from ``BaseMetadata`` and share the following parameters:
 
 * ``swaps`` (dict of str to str, default ``{}``) -- A dictionary of explicit replacement mappings. When a detected value matches a key, the corresponding value is used as the synthesized replacement instead of a generated one.
+* ``constant_value`` (str | None, default ``None``) -- A string value that will be used as the replacement, if there is not a value in ``swaps`` that matches.
 
 .. code-block:: python
 
@@ -44,6 +45,12 @@ All metadata classes inherit from ``BaseMetadata`` and share the following param
 
     # Always replace "Acme" with "Globex" instead of generating a random name
     metadata = NameGeneratorMetadata(swaps={"Acme": "Globex"})
+
+    # Always replace names with "Alice"
+    metadata = NameGeneratorMetadata(constant_value="Alice")
+
+    # Replace all names with "Bob" except for "Alice" which will be replaced with "Mary"
+    metadata = NameGeneratorMetadata(constant_value="Bob", swaps={"Alice": "Mary"})
 
 
 Name synthesis

--- a/tests/tests/metadata_tests/test_base_metadata_json.py
+++ b/tests/tests/metadata_tests/test_base_metadata_json.py
@@ -10,7 +10,8 @@ class TestBaseMetadataJsonSerialization:
         metadata = BaseMetadata(
             custom_generator=GeneratorType.Name,
             generator_version=GeneratorVersion.V2,
-            swaps={"foo": "bar"}
+            swaps={"foo": "bar"},
+            constant_value="REDACTED"
         )
         json_str = json.dumps(metadata)
 
@@ -19,6 +20,7 @@ class TestBaseMetadataJsonSerialization:
         assert parsed["customGenerator"] == "Name"
         assert parsed["generatorVersion"] == "V2"
         assert parsed["swaps"] == {"foo": "bar"}
+        assert parsed["constantValue"] == "REDACTED"
 
     def test_json_includes_type_field(self):
         """Serialized JSON should include _type for deserialization."""
@@ -38,13 +40,15 @@ class TestBaseMetadataJsonSerialization:
         assert restored.custom_generator == original.custom_generator
         assert restored.generator_version == original.generator_version
         assert restored.swaps == original.swaps
+        assert restored.constant_value is None
 
     def test_json_roundtrip_with_custom_values(self):
         """Round-trip serialization preserves custom values."""
         original = BaseMetadata(
             custom_generator=GeneratorType.DateTime,
             generator_version=GeneratorVersion.V2,
-            swaps={"original": "replaced"}
+            swaps={"original": "replaced"},
+            constant_value="STATIC"
         )
         json_str = json.dumps(original)
         parsed = json.loads(json_str)
@@ -53,6 +57,7 @@ class TestBaseMetadataJsonSerialization:
         assert restored.custom_generator == original.custom_generator
         assert restored.generator_version == original.generator_version
         assert restored.swaps == original.swaps
+        assert restored.constant_value == "STATIC"
 
     def test_attribute_access_works(self):
         """Property-based attribute access should work."""
@@ -72,6 +77,7 @@ class TestBaseMetadataJsonSerialization:
         metadata.custom_generator = GeneratorType.Email
         metadata.generator_version = GeneratorVersion.V2
         metadata.swaps = {"x": "y"}
+        metadata.constant_value = "FIXED"
 
         assert metadata.custom_generator == GeneratorType.Email
         assert metadata["customGenerator"] == GeneratorType.Email
@@ -79,6 +85,8 @@ class TestBaseMetadataJsonSerialization:
         assert metadata["generatorVersion"] == GeneratorVersion.V2
         assert metadata.swaps == {"x": "y"}
         assert metadata["swaps"] == {"x": "y"}
+        assert metadata.constant_value == "FIXED"
+        assert metadata["constantValue"] == "FIXED"
 
     def test_dict_access_works(self):
         """Direct dict access should work."""
@@ -109,3 +117,28 @@ class TestBaseMetadataJsonSerialization:
         parsed = json.loads(json_str)
 
         assert parsed["customGenerator"] is None
+
+    def test_constant_value_default_is_none(self):
+        """constant_value defaults to None."""
+        metadata = BaseMetadata()
+
+        assert metadata.constant_value is None
+        assert metadata["constantValue"] is None
+
+    def test_constant_value_serializes_correctly(self):
+        """constant_value round-trips through JSON."""
+        metadata = BaseMetadata(constant_value="[REDACTED]")
+        json_str = json.dumps(metadata)
+        parsed = json.loads(json_str)
+        restored = BaseMetadata.from_payload(parsed)
+
+        assert parsed["constantValue"] == "[REDACTED]"
+        assert restored.constant_value == "[REDACTED]"
+
+    def test_constant_value_none_serializes_as_null(self):
+        """None constant_value serializes to null in JSON."""
+        metadata = BaseMetadata(constant_value=None)
+        json_str = json.dumps(metadata)
+        parsed = json.loads(json_str)
+
+        assert parsed["constantValue"] is None

--- a/tests/tests/metadata_tests/test_date_time_generator_metadata_json.py
+++ b/tests/tests/metadata_tests/test_date_time_generator_metadata_json.py
@@ -16,7 +16,8 @@ class TestDateTimeGeneratorMetadataJsonSerialization:
             additional_date_formats=["yyyy-MM-dd"],
             apply_constant_shift_to_document=True,
             metadata=ts_metadata,
-            swaps={"date1": "date2"}
+            swaps={"date1": "date2"},
+            use_clear_date_and_passthrough_or_group_year_generator=True
         )
         json_str = json.dumps(metadata)
 
@@ -29,6 +30,7 @@ class TestDateTimeGeneratorMetadataJsonSerialization:
         assert parsed["applyConstantShiftToDocument"] is True
         assert parsed["metadata"]["leftShiftInDays"] == -30
         assert parsed["metadata"]["rightShiftInDays"] == 30
+        assert parsed["useClearDateAndPassthroughOrGroupYearGenerator"] is True
 
     def test_json_includes_type_field(self):
         """Serialized JSON should include _type for deserialization."""
@@ -52,6 +54,7 @@ class TestDateTimeGeneratorMetadataJsonSerialization:
         assert restored.apply_constant_shift_to_document == original.apply_constant_shift_to_document
         assert restored.metadata.left_shift_in_days == original.metadata.left_shift_in_days
         assert restored.metadata.right_shift_in_days == original.metadata.right_shift_in_days
+        assert restored.use_clear_date_and_passthrough_or_group_year_generator == False
 
     def test_json_roundtrip_with_custom_values(self):
         """Round-trip serialization preserves custom values."""
@@ -66,7 +69,8 @@ class TestDateTimeGeneratorMetadataJsonSerialization:
             additional_date_formats=["format1", "format2"],
             apply_constant_shift_to_document=True,
             metadata=ts_metadata,
-            swaps={"outer": "swap"}
+            swaps={"outer": "swap"},
+            use_clear_date_and_passthrough_or_group_year_generator=True
         )
         json_str = json.dumps(original)
         parsed = json.loads(json_str)
@@ -81,6 +85,7 @@ class TestDateTimeGeneratorMetadataJsonSerialization:
         assert restored.metadata.right_shift_in_days == 100
         assert restored.metadata.swaps == {"ts_key": "ts_val"}
         assert restored.swaps == {"outer": "swap"}
+        assert restored.use_clear_date_and_passthrough_or_group_year_generator is True
 
     def test_attribute_access_works(self):
         """Property-based attribute access should work."""
@@ -98,11 +103,14 @@ class TestDateTimeGeneratorMetadataJsonSerialization:
         metadata = DateTimeGeneratorMetadata()
         metadata.additional_date_formats = ["new-format"]
         metadata.apply_constant_shift_to_document = True
+        metadata.use_clear_date_and_passthrough_or_group_year_generator = True
 
         assert metadata.additional_date_formats == ["new-format"]
         assert metadata["additionalDateFormats"] == ["new-format"]
         assert metadata.apply_constant_shift_to_document is True
         assert metadata["applyConstantShiftToDocument"] is True
+        assert metadata.use_clear_date_and_passthrough_or_group_year_generator is True
+        assert metadata["useClearDateAndPassthroughOrGroupYearGenerator"] is True
 
     def test_dict_access_works(self):
         """Direct dict access should work."""
@@ -110,6 +118,7 @@ class TestDateTimeGeneratorMetadataJsonSerialization:
 
         assert metadata["additionalDateFormats"] == ["test"]
         assert metadata["_type"] == "DateTimeGeneratorMetadata"
+        assert "useClearDateAndPassthroughOrGroupYearGenerator" in metadata
 
     def test_to_payload_returns_dict_copy(self):
         """to_payload() should return a dict copy of the metadata."""

--- a/tests/tests/metadata_tests/test_date_time_generator_metadata_json.py
+++ b/tests/tests/metadata_tests/test_date_time_generator_metadata_json.py
@@ -54,7 +54,7 @@ class TestDateTimeGeneratorMetadataJsonSerialization:
         assert restored.apply_constant_shift_to_document == original.apply_constant_shift_to_document
         assert restored.metadata.left_shift_in_days == original.metadata.left_shift_in_days
         assert restored.metadata.right_shift_in_days == original.metadata.right_shift_in_days
-        assert restored.use_clear_date_and_passthrough_or_group_year_generator == False
+        assert restored.use_clear_date_and_passthrough_or_group_year_generator is False
 
     def test_json_roundtrip_with_custom_values(self):
         """Round-trip serialization preserves custom values."""

--- a/tests/tests/metadata_tests/test_hipaa_address_generator_metadata_json.py
+++ b/tests/tests/metadata_tests/test_hipaa_address_generator_metadata_json.py
@@ -13,7 +13,9 @@ class TestHipaaAddressGeneratorMetadataJsonSerialization:
             use_non_hipaa_address_generator=True,
             replace_truncated_zeros_in_zip_code=False,
             realistic_synthetic_values=False,
-            swaps={"Atlanta": "Boston"}
+            swaps={"Atlanta": "Boston"},
+            use_three_digit_zips=True,
+            replace_foreign_zip_codes_with_zeros=True
         )
         json_str = json.dumps(metadata)
 
@@ -25,6 +27,8 @@ class TestHipaaAddressGeneratorMetadataJsonSerialization:
         assert parsed["replaceTruncatedZerosInZipCode"] is False
         assert parsed["realisticSyntheticValues"] is False
         assert parsed["swaps"] == {"Atlanta": "Boston"}
+        assert parsed["useThreeDigitZips"] is True
+        assert parsed["replaceForeignZipCodesWithZeros"] is True
 
     def test_json_includes_type_field(self):
         """Serialized JSON should include _type for deserialization."""
@@ -47,6 +51,8 @@ class TestHipaaAddressGeneratorMetadataJsonSerialization:
         assert restored.replace_truncated_zeros_in_zip_code == original.replace_truncated_zeros_in_zip_code
         assert restored.realistic_synthetic_values == original.realistic_synthetic_values
         assert restored.swaps == original.swaps
+        assert restored.use_three_digit_zips == False
+        assert restored.replace_foreign_zip_codes_with_zeros == False
 
     def test_json_roundtrip_with_custom_values(self):
         """Round-trip serialization preserves custom values."""
@@ -55,7 +61,9 @@ class TestHipaaAddressGeneratorMetadataJsonSerialization:
             use_non_hipaa_address_generator=True,
             replace_truncated_zeros_in_zip_code=False,
             realistic_synthetic_values=False,
-            swaps={"city1": "city2"}
+            swaps={"city1": "city2"},
+            use_three_digit_zips=True,
+            replace_foreign_zip_codes_with_zeros=True
         )
         json_str = json.dumps(original)
         parsed = json.loads(json_str)
@@ -67,6 +75,8 @@ class TestHipaaAddressGeneratorMetadataJsonSerialization:
         assert restored.replace_truncated_zeros_in_zip_code is False
         assert restored.realistic_synthetic_values is False
         assert restored.swaps == {"city1": "city2"}
+        assert restored.use_three_digit_zips is True
+        assert restored.replace_foreign_zip_codes_with_zeros is True
 
     def test_attribute_access_works(self):
         """Property-based attribute access should work."""
@@ -85,6 +95,8 @@ class TestHipaaAddressGeneratorMetadataJsonSerialization:
         metadata.use_non_hipaa_address_generator = True
         metadata.replace_truncated_zeros_in_zip_code = False
         metadata.realistic_synthetic_values = False
+        metadata.use_three_digit_zips = True
+        metadata.replace_foreign_zip_codes_with_zeros = True
 
         assert metadata.use_non_hipaa_address_generator is True
         assert metadata["useNonHipaaAddressGenerator"] is True
@@ -92,6 +104,10 @@ class TestHipaaAddressGeneratorMetadataJsonSerialization:
         assert metadata["replaceTruncatedZerosInZipCode"] is False
         assert metadata.realistic_synthetic_values is False
         assert metadata["realisticSyntheticValues"] is False
+        assert metadata.use_three_digit_zips is True
+        assert metadata["useThreeDigitZips"] is True
+        assert metadata.replace_foreign_zip_codes_with_zeros is True
+        assert metadata["replaceForeignZipCodesWithZeros"] is True
 
     def test_dict_access_works(self):
         """Direct dict access should work."""
@@ -99,6 +115,8 @@ class TestHipaaAddressGeneratorMetadataJsonSerialization:
 
         assert metadata["useNonHipaaAddressGenerator"] is True
         assert metadata["_type"] == "HipaaAddressGeneratorMetadata"
+        assert "useThreeDigitZips" in metadata
+        assert "replaceForeignZipCodesWithZeros" in metadata
 
     def test_to_payload_returns_dict_copy(self):
         """to_payload() should return a dict copy of the metadata."""

--- a/tests/tests/metadata_tests/test_hipaa_address_generator_metadata_json.py
+++ b/tests/tests/metadata_tests/test_hipaa_address_generator_metadata_json.py
@@ -51,8 +51,8 @@ class TestHipaaAddressGeneratorMetadataJsonSerialization:
         assert restored.replace_truncated_zeros_in_zip_code == original.replace_truncated_zeros_in_zip_code
         assert restored.realistic_synthetic_values == original.realistic_synthetic_values
         assert restored.swaps == original.swaps
-        assert restored.use_three_digit_zips == False
-        assert restored.replace_foreign_zip_codes_with_zeros == False
+        assert restored.use_three_digit_zips is False
+        assert restored.replace_foreign_zip_codes_with_zeros is False
 
     def test_json_roundtrip_with_custom_values(self):
         """Round-trip serialization preserves custom values."""

--- a/tests/tests/metadata_tests/test_payload_serialization.py
+++ b/tests/tests/metadata_tests/test_payload_serialization.py
@@ -87,13 +87,15 @@ class TestNameGeneratorMetadata:
         assert payload["swaps"] == {}
         assert payload["isConsistencyCaseSensitive"] is False
         assert payload["preserveGender"] is False
+        assert payload["constantValue"] is None
 
     def test_to_payload_with_values(self):
         metadata = NameGeneratorMetadata(
             generator_version=GeneratorVersion.V2,
             is_consistency_case_sensitive=True,
             preserve_gender=True,
-            swaps={"John": "Jane"}
+            swaps={"John": "Jane"},
+            constant_value="REDACTED"
         )
         payload = metadata.to_payload()
 
@@ -102,6 +104,7 @@ class TestNameGeneratorMetadata:
         assert payload["swaps"] == {"John": "Jane"}
         assert payload["isConsistencyCaseSensitive"] is True
         assert payload["preserveGender"] is True
+        assert payload["constantValue"] == "REDACTED"
 
     def test_from_payload_defaults(self):
         payload = {"customGenerator": "Name"}
@@ -112,6 +115,7 @@ class TestNameGeneratorMetadata:
         assert metadata.swaps == {}
         assert metadata.is_consistency_case_sensitive is False
         assert metadata.preserve_gender is False
+        assert metadata.constant_value is None
 
     def test_from_payload_with_values(self):
         payload = {
@@ -119,7 +123,8 @@ class TestNameGeneratorMetadata:
             "generatorVersion": GeneratorVersion.V2,
             "swaps": {"Alice": "Bob"},
             "isConsistencyCaseSensitive": True,
-            "preserveGender": True
+            "preserveGender": True,
+            "constantValue": "REDACTED"
         }
         metadata = NameGeneratorMetadata.from_payload(payload)
 
@@ -128,6 +133,7 @@ class TestNameGeneratorMetadata:
         assert metadata.swaps == {"Alice": "Bob"}
         assert metadata.is_consistency_case_sensitive is True
         assert metadata.preserve_gender is True
+        assert metadata.constant_value == "REDACTED"
 
     def test_from_payload_invalid_generator_raises(self):
         payload = {"customGenerator": "DateTime"}
@@ -140,7 +146,8 @@ class TestNameGeneratorMetadata:
             generator_version=GeneratorVersion.V2,
             is_consistency_case_sensitive=True,
             preserve_gender=True,
-            swaps={"name1": "name2"}
+            swaps={"name1": "name2"},
+            constant_value="REDACTED"
         )
         payload = original.to_payload()
         payload["customGenerator"] = payload["customGenerator"].value
@@ -151,6 +158,7 @@ class TestNameGeneratorMetadata:
         assert restored.swaps == original.swaps
         assert restored.is_consistency_case_sensitive == original.is_consistency_case_sensitive
         assert restored.preserve_gender == original.preserve_gender
+        assert restored.constant_value == original.constant_value
 
 
 class TestHipaaAddressGeneratorMetadata:
@@ -166,6 +174,7 @@ class TestHipaaAddressGeneratorMetadata:
         assert payload["realisticSyntheticValues"] is True
         assert payload["useThreeDigitZips"] is False
         assert payload["replaceForeignZipCodesWithZeros"] is False
+        assert payload["constantValue"] is None
 
     def test_to_payload_with_values(self):
         metadata = HipaaAddressGeneratorMetadata(
@@ -175,7 +184,8 @@ class TestHipaaAddressGeneratorMetadata:
             realistic_synthetic_values=False,
             swaps={"Atlanta": "Boston"},
             use_three_digit_zips=True,
-            replace_foreign_zip_codes_with_zeros=True
+            replace_foreign_zip_codes_with_zeros=True,
+            constant_value="REDACTED"
         )
         payload = metadata.to_payload()
 
@@ -187,6 +197,7 @@ class TestHipaaAddressGeneratorMetadata:
         assert payload["realisticSyntheticValues"] is False
         assert payload["useThreeDigitZips"] is True
         assert payload["replaceForeignZipCodesWithZeros"] is True
+        assert payload["constantValue"] == "REDACTED"
 
     def test_from_payload_defaults(self):
         payload = {"customGenerator": "HipaaAddressGenerator"}
@@ -200,6 +211,7 @@ class TestHipaaAddressGeneratorMetadata:
         assert metadata.realistic_synthetic_values is True
         assert metadata.use_three_digit_zips is False
         assert metadata.replace_foreign_zip_codes_with_zeros is False
+        assert metadata.constant_value is None
 
     def test_from_payload_with_values(self):
         payload = {
@@ -210,7 +222,8 @@ class TestHipaaAddressGeneratorMetadata:
             "replaceTruncatedZerosInZipCode": False,
             "realisticSyntheticValues": False,
             "useThreeDigitZips": True,
-            "replaceForeignZipCodesWithZeros": True
+            "replaceForeignZipCodesWithZeros": True,
+            "constantValue": "REDACTED"
         }
         metadata = HipaaAddressGeneratorMetadata.from_payload(payload)
 
@@ -222,6 +235,7 @@ class TestHipaaAddressGeneratorMetadata:
         assert metadata.realistic_synthetic_values is False
         assert metadata.use_three_digit_zips is True
         assert metadata.replace_foreign_zip_codes_with_zeros is True
+        assert metadata.constant_value == "REDACTED"
 
     def test_from_payload_invalid_generator_raises(self):
         payload = {"customGenerator": "Name"}
@@ -237,7 +251,8 @@ class TestHipaaAddressGeneratorMetadata:
             realistic_synthetic_values=False,
             swaps={"city1": "city2"},
             use_three_digit_zips=True,
-            replace_foreign_zip_codes_with_zeros=True
+            replace_foreign_zip_codes_with_zeros=True,
+            constant_value="REDACTED"
         )
         payload = original.to_payload()
         payload["customGenerator"] = payload["customGenerator"].value
@@ -251,6 +266,7 @@ class TestHipaaAddressGeneratorMetadata:
         assert restored.realistic_synthetic_values == original.realistic_synthetic_values
         assert restored.use_three_digit_zips == original.use_three_digit_zips
         assert restored.replace_foreign_zip_codes_with_zeros == original.replace_foreign_zip_codes_with_zeros
+        assert restored.constant_value == original.constant_value
 
 
 class TestNumericValueGeneratorMetadata:
@@ -262,12 +278,14 @@ class TestNumericValueGeneratorMetadata:
         assert payload["generatorVersion"] == GeneratorVersion.V1
         assert payload["swaps"] == {}
         assert payload["useOracleIntegerPkGenerator"] is False
+        assert payload["constantValue"] is None
 
     def test_to_payload_with_values(self):
         metadata = NumericValueGeneratorMetadata(
             generator_version=GeneratorVersion.V2,
             use_oracle_integer_pk_generator=True,
-            swaps={"123": "456"}
+            swaps={"123": "456"},
+            constant_value="REDACTED"
         )
         payload = metadata.to_payload()
 
@@ -275,6 +293,7 @@ class TestNumericValueGeneratorMetadata:
         assert payload["generatorVersion"] == GeneratorVersion.V2
         assert payload["swaps"] == {"123": "456"}
         assert payload["useOracleIntegerPkGenerator"] is True
+        assert payload["constantValue"] == "REDACTED"
 
     def test_from_payload_defaults(self):
         payload = {"customGenerator": "NumericValue"}
@@ -284,13 +303,15 @@ class TestNumericValueGeneratorMetadata:
         assert metadata.generator_version == GeneratorVersion.V1
         assert metadata.swaps == {}
         assert metadata.use_oracle_integer_pk_generator is False
+        assert metadata.constant_value is None
 
     def test_from_payload_with_values(self):
         payload = {
             "customGenerator": "NumericValue",
             "generatorVersion": GeneratorVersion.V2,
             "swaps": {"100": "200"},
-            "useOracleIntegerPkGenerator": True
+            "useOracleIntegerPkGenerator": True,
+            "constantValue": "REDACTED"
         }
         metadata = NumericValueGeneratorMetadata.from_payload(payload)
 
@@ -298,6 +319,7 @@ class TestNumericValueGeneratorMetadata:
         assert metadata.generator_version == GeneratorVersion.V2
         assert metadata.swaps == {"100": "200"}
         assert metadata.use_oracle_integer_pk_generator is True
+        assert metadata.constant_value == "REDACTED"
 
     def test_from_payload_invalid_generator_raises(self):
         payload = {"customGenerator": "Name"}
@@ -309,7 +331,8 @@ class TestNumericValueGeneratorMetadata:
         original = NumericValueGeneratorMetadata(
             generator_version=GeneratorVersion.V2,
             use_oracle_integer_pk_generator=True,
-            swaps={"val1": "val2"}
+            swaps={"val1": "val2"},
+            constant_value="REDACTED"
         )
         payload = original.to_payload()
         payload["customGenerator"] = payload["customGenerator"].value
@@ -319,6 +342,7 @@ class TestNumericValueGeneratorMetadata:
         assert restored.generator_version == original.generator_version
         assert restored.swaps == original.swaps
         assert restored.use_oracle_integer_pk_generator == original.use_oracle_integer_pk_generator
+        assert restored.constant_value == original.constant_value
 
 
 class TestPhoneNumberGeneratorMetadata:
@@ -331,13 +355,15 @@ class TestPhoneNumberGeneratorMetadata:
         assert payload["swaps"] == {}
         assert payload["useUsPhoneNumberGenerator"] is False
         assert payload["replaceInvalidNumbers"] is True
+        assert payload["constantValue"] is None
 
     def test_to_payload_with_values(self):
         metadata = PhoneNumberGeneratorMetadata(
             generator_version=GeneratorVersion.V2,
             use_us_phone_number_generator=True,
             replace_invalid_numbers=False,
-            swaps={"555-1234": "555-5678"}
+            swaps={"555-1234": "555-5678"},
+            constant_value="REDACTED"
         )
         payload = metadata.to_payload()
 
@@ -346,6 +372,7 @@ class TestPhoneNumberGeneratorMetadata:
         assert payload["swaps"] == {"555-1234": "555-5678"}
         assert payload["useUsPhoneNumberGenerator"] is True
         assert payload["replaceInvalidNumbers"] is False
+        assert payload["constantValue"] == "REDACTED"
 
     def test_from_payload_defaults(self):
         payload = {"customGenerator": "PhoneNumber"}
@@ -356,6 +383,7 @@ class TestPhoneNumberGeneratorMetadata:
         assert metadata.swaps == {}
         assert metadata.use_us_phone_number_generator is False
         assert metadata.replace_invalid_numbers is True
+        assert metadata.constant_value is None
 
     def test_from_payload_with_values(self):
         payload = {
@@ -363,7 +391,8 @@ class TestPhoneNumberGeneratorMetadata:
             "generatorVersion": GeneratorVersion.V2,
             "swaps": {"111": "222"},
             "useUsPhoneNumberGenerator": True,
-            "replaceInvalidNumbers": False
+            "replaceInvalidNumbers": False,
+            "constantValue": "REDACTED"
         }
         metadata = PhoneNumberGeneratorMetadata.from_payload(payload)
 
@@ -372,6 +401,7 @@ class TestPhoneNumberGeneratorMetadata:
         assert metadata.swaps == {"111": "222"}
         assert metadata.use_us_phone_number_generator is True
         assert metadata.replace_invalid_numbers is False
+        assert metadata.constant_value == "REDACTED"
 
     def test_from_payload_invalid_generator_raises(self):
         payload = {"customGenerator": "Name"}
@@ -384,7 +414,8 @@ class TestPhoneNumberGeneratorMetadata:
             generator_version=GeneratorVersion.V2,
             use_us_phone_number_generator=True,
             replace_invalid_numbers=False,
-            swaps={"phone1": "phone2"}
+            swaps={"phone1": "phone2"},
+            constant_value="REDACTED"
         )
         payload = original.to_payload()
         payload["customGenerator"] = payload["customGenerator"].value
@@ -395,6 +426,7 @@ class TestPhoneNumberGeneratorMetadata:
         assert restored.swaps == original.swaps
         assert restored.use_us_phone_number_generator == original.use_us_phone_number_generator
         assert restored.replace_invalid_numbers == original.replace_invalid_numbers
+        assert restored.constant_value == original.constant_value
 
 
 class TestBaseDateTimeGeneratorMetadata:
@@ -406,13 +438,15 @@ class TestBaseDateTimeGeneratorMetadata:
         assert payload["generatorVersion"] == GeneratorVersion.V1
         assert payload["swaps"] == {}
         assert payload["scrambleUnrecognizedDates"] is True
+        assert payload["constantValue"] is None
 
     def test_to_payload_with_values(self):
         metadata = BaseDateTimeGeneratorMetadata(
             custom_generator=GeneratorType.DateTime,
             generator_version=GeneratorVersion.V2,
             scramble_unrecognized_dates=False,
-            swaps={"2024-01-01": "2025-01-01"}
+            swaps={"2024-01-01": "2025-01-01"},
+            constant_value="REDACTED"
         )
         payload = metadata.to_payload()
 
@@ -420,6 +454,7 @@ class TestBaseDateTimeGeneratorMetadata:
         assert payload["generatorVersion"] == GeneratorVersion.V2
         assert payload["swaps"] == {"2024-01-01": "2025-01-01"}
         assert payload["scrambleUnrecognizedDates"] is False
+        assert payload["constantValue"] == "REDACTED"
 
     def test_from_payload_defaults(self):
         metadata = BaseDateTimeGeneratorMetadata.from_payload({})
@@ -428,13 +463,15 @@ class TestBaseDateTimeGeneratorMetadata:
         assert metadata.generator_version == GeneratorVersion.V1
         assert metadata.swaps == {}
         assert metadata.scramble_unrecognized_dates is True
+        assert metadata.constant_value is None
 
     def test_from_payload_with_values(self):
         payload = {
             "customGenerator": "DateTime",
             "generatorVersion": GeneratorVersion.V2,
             "swaps": {"date1": "date2"},
-            "scrambleUnrecognizedDates": False
+            "scrambleUnrecognizedDates": False,
+            "constantValue": "REDACTED"
         }
         metadata = BaseDateTimeGeneratorMetadata.from_payload(payload)
 
@@ -442,13 +479,15 @@ class TestBaseDateTimeGeneratorMetadata:
         assert metadata.generator_version == GeneratorVersion.V2
         assert metadata.swaps == {"date1": "date2"}
         assert metadata.scramble_unrecognized_dates is False
+        assert metadata.constant_value == "REDACTED"
 
     def test_roundtrip(self):
         original = BaseDateTimeGeneratorMetadata(
             custom_generator=GeneratorType.PersonAge,
             generator_version=GeneratorVersion.V2,
             scramble_unrecognized_dates=False,
-            swaps={"a": "b"}
+            swaps={"a": "b"},
+            constant_value="REDACTED"
         )
         payload = original.to_payload()
         payload["customGenerator"] = payload["customGenerator"].value
@@ -458,6 +497,7 @@ class TestBaseDateTimeGeneratorMetadata:
         assert restored.generator_version == original.generator_version
         assert restored.swaps == original.swaps
         assert restored.scramble_unrecognized_dates == original.scramble_unrecognized_dates
+        assert restored.constant_value == original.constant_value
 
 
 class TestDateTimeGeneratorMetadata:
@@ -475,6 +515,7 @@ class TestDateTimeGeneratorMetadata:
         assert payload["metadata"]["leftShiftInDays"] == -7
         assert payload["metadata"]["rightShiftInDays"] == 7
         assert payload["useClearDateAndPassthroughOrGroupYearGenerator"] is False
+        assert payload["constantValue"] is None
 
     def test_to_payload_with_values(self):
         ts_metadata = TimestampShiftMetadata(
@@ -489,7 +530,8 @@ class TestDateTimeGeneratorMetadata:
             apply_constant_shift_to_document=True,
             metadata=ts_metadata,
             swaps={"date": "newdate"},
-            use_clear_date_and_passthrough_or_group_year_generator=True
+            use_clear_date_and_passthrough_or_group_year_generator=True,
+            constant_value="REDACTED"
         )
         payload = metadata.to_payload()
 
@@ -503,6 +545,7 @@ class TestDateTimeGeneratorMetadata:
         assert payload["metadata"]["rightShiftInDays"] == 30
         assert payload["metadata"]["swaps"] == {"ts1": "ts2"}
         assert payload["useClearDateAndPassthroughOrGroupYearGenerator"] is True
+        assert payload["constantValue"] == "REDACTED"
 
     def test_from_payload_defaults(self):
         payload = {"customGenerator": "DateTime"}
@@ -517,6 +560,7 @@ class TestDateTimeGeneratorMetadata:
         assert metadata.metadata.left_shift_in_days == -7
         assert metadata.metadata.right_shift_in_days == 7
         assert metadata.use_clear_date_and_passthrough_or_group_year_generator is False
+        assert metadata.constant_value is None
 
     def test_from_payload_with_values(self):
         payload = {
@@ -531,7 +575,8 @@ class TestDateTimeGeneratorMetadata:
                 "rightShiftInDays": 100,
                 "swaps": {"inner": "swap"}
             },
-            "useClearDateAndPassthroughOrGroupYearGenerator": True
+            "useClearDateAndPassthroughOrGroupYearGenerator": True,
+            "constantValue": "REDACTED"
         }
         metadata = DateTimeGeneratorMetadata.from_payload(payload)
 
@@ -545,6 +590,7 @@ class TestDateTimeGeneratorMetadata:
         assert metadata.metadata.right_shift_in_days == 100
         assert metadata.metadata.swaps == {"inner": "swap"}
         assert metadata.use_clear_date_and_passthrough_or_group_year_generator is True
+        assert metadata.constant_value == "REDACTED"
 
     def test_from_payload_invalid_generator_raises(self):
         payload = {"customGenerator": "Name"}
@@ -565,7 +611,8 @@ class TestDateTimeGeneratorMetadata:
             apply_constant_shift_to_document=True,
             metadata=ts_metadata,
             swaps={"outer": "swap"},
-            use_clear_date_and_passthrough_or_group_year_generator=True
+            use_clear_date_and_passthrough_or_group_year_generator=True,
+            constant_value="REDACTED"
         )
         payload = original.to_payload()
         payload["customGenerator"] = payload["customGenerator"].value
@@ -581,6 +628,7 @@ class TestDateTimeGeneratorMetadata:
         assert restored.metadata.right_shift_in_days == original.metadata.right_shift_in_days
         assert restored.metadata.swaps == original.metadata.swaps
         assert restored.use_clear_date_and_passthrough_or_group_year_generator == original.use_clear_date_and_passthrough_or_group_year_generator
+        assert restored.constant_value == original.constant_value
 
 
 class TestPersonAgeGeneratorMetadata:
@@ -595,6 +643,7 @@ class TestPersonAgeGeneratorMetadata:
         assert "metadata" in payload
         assert payload["metadata"]["ageShiftInYears"] == 7
         assert payload["usePassthroughOrGroupAgeGenerator"] is False
+        assert payload["constantValue"] is None
 
     def test_to_payload_with_values(self):
         age_metadata = AgeShiftMetadata(age_shift_in_years=15)
@@ -603,7 +652,8 @@ class TestPersonAgeGeneratorMetadata:
             scramble_unrecognized_dates=False,
             metadata=age_metadata,
             swaps={"30": "35"},
-            use_passthrough_or_group_age_generator=True
+            use_passthrough_or_group_age_generator=True,
+            constant_value="REDACTED"
         )
         payload = metadata.to_payload()
 
@@ -613,6 +663,7 @@ class TestPersonAgeGeneratorMetadata:
         assert payload["scrambleUnrecognizedDates"] is False
         assert payload["metadata"]["ageShiftInYears"] == 15
         assert payload["usePassthroughOrGroupAgeGenerator"] is True
+        assert payload["constantValue"] == "REDACTED"
 
     def test_from_payload_defaults(self):
         payload = {"customGenerator": "PersonAge"}
@@ -624,6 +675,7 @@ class TestPersonAgeGeneratorMetadata:
         assert metadata.scramble_unrecognized_dates is True
         assert metadata.metadata.age_shift_in_years == 7
         assert metadata.use_passthrough_or_group_age_generator is False
+        assert metadata.constant_value is None
 
     def test_from_payload_with_values(self):
         payload = {
@@ -634,7 +686,8 @@ class TestPersonAgeGeneratorMetadata:
             "metadata": {
                 "ageShiftInYears": 25
             },
-            "usePassthroughOrGroupAgeGenerator": True
+            "usePassthroughOrGroupAgeGenerator": True,
+            "constantValue": "REDACTED"
         }
         metadata = PersonAgeGeneratorMetadata.from_payload(payload)
 
@@ -644,6 +697,7 @@ class TestPersonAgeGeneratorMetadata:
         assert metadata.scramble_unrecognized_dates is False
         assert metadata.metadata.age_shift_in_years == 25
         assert metadata.use_passthrough_or_group_age_generator is True
+        assert metadata.constant_value == "REDACTED"
 
     def test_from_payload_invalid_generator_raises(self):
         payload = {"customGenerator": "DateTime"}
@@ -658,7 +712,8 @@ class TestPersonAgeGeneratorMetadata:
             scramble_unrecognized_dates=False,
             metadata=age_metadata,
             swaps={"swap1": "swap2"},
-            use_passthrough_or_group_age_generator=True
+            use_passthrough_or_group_age_generator=True,
+            constant_value="REDACTED"
         )
         payload = original.to_payload()
         payload["customGenerator"] = payload["customGenerator"].value
@@ -670,6 +725,7 @@ class TestPersonAgeGeneratorMetadata:
         assert restored.scramble_unrecognized_dates == original.scramble_unrecognized_dates
         assert restored.metadata.age_shift_in_years == original.metadata.age_shift_in_years
         assert restored.use_passthrough_or_group_age_generator == original.use_passthrough_or_group_age_generator
+        assert restored.constant_value == original.constant_value
 
 
 class TestTimestampShiftMetadata:

--- a/tests/tests/metadata_tests/test_payload_serialization.py
+++ b/tests/tests/metadata_tests/test_payload_serialization.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 from tonic_textual.classes.generator_metadata.base_metadata import BaseMetadata
@@ -87,7 +87,7 @@ class TestBaseMetadata:
         (True, "True"),
         (False, "False"),
     ] )
-    def test_can_deserialize_bare_values_for_constant_value(self, json_value: Any, expected_value: str | None):
+    def test_can_deserialize_bare_values_for_constant_value(self, json_value: Any, expected_value: Optional[str]):
         payload = {
             "customGenerator": "Name",
             "generatorVersion": GeneratorVersion.V2,
@@ -859,7 +859,7 @@ class TestAgeShiftMetadata:
         (True, "True"),
         (False, "False"),
     ])
-    def test_can_deserialize_bare_values_for_constant_value(self, json_value: Any, expected_value: str | None):
+    def test_can_deserialize_bare_values_for_constant_value(self, json_value: Any, expected_value: Optional[str]):
         payload = {
             "customGenerator": "Name",
             "generatorVersion": GeneratorVersion.V2,

--- a/tests/tests/metadata_tests/test_payload_serialization.py
+++ b/tests/tests/metadata_tests/test_payload_serialization.py
@@ -21,18 +21,21 @@ class TestBaseMetadata:
         assert payload["customGenerator"] is None
         assert payload["generatorVersion"] == GeneratorVersion.V1
         assert payload["swaps"] == {}
+        assert payload["constantValue"] is None
 
     def test_to_payload_with_values(self):
         metadata = BaseMetadata(
             custom_generator=GeneratorType.Name,
             generator_version=GeneratorVersion.V2,
-            swaps={"foo": "bar"}
+            swaps={"foo": "bar"},
+            constant_value="REDACTED"
         )
         payload = metadata.to_payload()
 
         assert payload["customGenerator"] == GeneratorType.Name
         assert payload["generatorVersion"] == GeneratorVersion.V2
         assert payload["swaps"] == {"foo": "bar"}
+        assert payload["constantValue"] == "REDACTED"
 
     def test_from_payload_empty(self):
         metadata = BaseMetadata.from_payload({})
@@ -40,24 +43,28 @@ class TestBaseMetadata:
         assert metadata.custom_generator is None
         assert metadata.generator_version == GeneratorVersion.V1
         assert metadata.swaps == {}
+        assert metadata.constant_value is None
 
     def test_from_payload_with_values(self):
         payload = {
             "customGenerator": "Name",
             "generatorVersion": GeneratorVersion.V2,
-            "swaps": {"key": "value"}
+            "swaps": {"key": "value"},
+            "constantValue": "STATIC"
         }
         metadata = BaseMetadata.from_payload(payload)
 
         assert metadata.custom_generator == GeneratorType.Name
         assert metadata.generator_version == GeneratorVersion.V2
         assert metadata.swaps == {"key": "value"}
+        assert metadata.constant_value == "STATIC"
 
     def test_roundtrip(self):
         original = BaseMetadata(
             custom_generator=GeneratorType.DateTime,
             generator_version=GeneratorVersion.V2,
-            swaps={"original": "replaced"}
+            swaps={"original": "replaced"},
+            constant_value="FIXED"
         )
         payload = original.to_payload()
         # Convert enum to string as would happen in JSON serialization
@@ -67,6 +74,7 @@ class TestBaseMetadata:
         assert restored.custom_generator == original.custom_generator
         assert restored.generator_version == original.generator_version
         assert restored.swaps == original.swaps
+        assert restored.constant_value == original.constant_value
 
 
 class TestNameGeneratorMetadata:
@@ -156,6 +164,8 @@ class TestHipaaAddressGeneratorMetadata:
         assert payload["useNonHipaaAddressGenerator"] is False
         assert payload["replaceTruncatedZerosInZipCode"] is True
         assert payload["realisticSyntheticValues"] is True
+        assert payload["useThreeDigitZips"] is False
+        assert payload["replaceForeignZipCodesWithZeros"] is False
 
     def test_to_payload_with_values(self):
         metadata = HipaaAddressGeneratorMetadata(
@@ -163,7 +173,9 @@ class TestHipaaAddressGeneratorMetadata:
             use_non_hipaa_address_generator=True,
             replace_truncated_zeros_in_zip_code=False,
             realistic_synthetic_values=False,
-            swaps={"Atlanta": "Boston"}
+            swaps={"Atlanta": "Boston"},
+            use_three_digit_zips=True,
+            replace_foreign_zip_codes_with_zeros=True
         )
         payload = metadata.to_payload()
 
@@ -173,6 +185,8 @@ class TestHipaaAddressGeneratorMetadata:
         assert payload["useNonHipaaAddressGenerator"] is True
         assert payload["replaceTruncatedZerosInZipCode"] is False
         assert payload["realisticSyntheticValues"] is False
+        assert payload["useThreeDigitZips"] is True
+        assert payload["replaceForeignZipCodesWithZeros"] is True
 
     def test_from_payload_defaults(self):
         payload = {"customGenerator": "HipaaAddressGenerator"}
@@ -184,6 +198,8 @@ class TestHipaaAddressGeneratorMetadata:
         assert metadata.use_non_hipaa_address_generator is False
         assert metadata.replace_truncated_zeros_in_zip_code is True
         assert metadata.realistic_synthetic_values is True
+        assert metadata.use_three_digit_zips is False
+        assert metadata.replace_foreign_zip_codes_with_zeros is False
 
     def test_from_payload_with_values(self):
         payload = {
@@ -192,7 +208,9 @@ class TestHipaaAddressGeneratorMetadata:
             "swaps": {"NY": "CA"},
             "useNonHipaaAddressGenerator": True,
             "replaceTruncatedZerosInZipCode": False,
-            "realisticSyntheticValues": False
+            "realisticSyntheticValues": False,
+            "useThreeDigitZips": True,
+            "replaceForeignZipCodesWithZeros": True
         }
         metadata = HipaaAddressGeneratorMetadata.from_payload(payload)
 
@@ -202,6 +220,8 @@ class TestHipaaAddressGeneratorMetadata:
         assert metadata.use_non_hipaa_address_generator is True
         assert metadata.replace_truncated_zeros_in_zip_code is False
         assert metadata.realistic_synthetic_values is False
+        assert metadata.use_three_digit_zips is True
+        assert metadata.replace_foreign_zip_codes_with_zeros is True
 
     def test_from_payload_invalid_generator_raises(self):
         payload = {"customGenerator": "Name"}
@@ -215,7 +235,9 @@ class TestHipaaAddressGeneratorMetadata:
             use_non_hipaa_address_generator=True,
             replace_truncated_zeros_in_zip_code=False,
             realistic_synthetic_values=False,
-            swaps={"city1": "city2"}
+            swaps={"city1": "city2"},
+            use_three_digit_zips=True,
+            replace_foreign_zip_codes_with_zeros=True
         )
         payload = original.to_payload()
         payload["customGenerator"] = payload["customGenerator"].value
@@ -227,6 +249,8 @@ class TestHipaaAddressGeneratorMetadata:
         assert restored.use_non_hipaa_address_generator == original.use_non_hipaa_address_generator
         assert restored.replace_truncated_zeros_in_zip_code == original.replace_truncated_zeros_in_zip_code
         assert restored.realistic_synthetic_values == original.realistic_synthetic_values
+        assert restored.use_three_digit_zips == original.use_three_digit_zips
+        assert restored.replace_foreign_zip_codes_with_zeros == original.replace_foreign_zip_codes_with_zeros
 
 
 class TestNumericValueGeneratorMetadata:
@@ -450,6 +474,7 @@ class TestDateTimeGeneratorMetadata:
         assert "metadata" in payload
         assert payload["metadata"]["leftShiftInDays"] == -7
         assert payload["metadata"]["rightShiftInDays"] == 7
+        assert payload["useClearDateAndPassthroughOrGroupYearGenerator"] is False
 
     def test_to_payload_with_values(self):
         ts_metadata = TimestampShiftMetadata(
@@ -463,7 +488,8 @@ class TestDateTimeGeneratorMetadata:
             additional_date_formats=["yyyy-MM-dd", "dd/MM/yyyy"],
             apply_constant_shift_to_document=True,
             metadata=ts_metadata,
-            swaps={"date": "newdate"}
+            swaps={"date": "newdate"},
+            use_clear_date_and_passthrough_or_group_year_generator=True
         )
         payload = metadata.to_payload()
 
@@ -476,6 +502,7 @@ class TestDateTimeGeneratorMetadata:
         assert payload["metadata"]["leftShiftInDays"] == -30
         assert payload["metadata"]["rightShiftInDays"] == 30
         assert payload["metadata"]["swaps"] == {"ts1": "ts2"}
+        assert payload["useClearDateAndPassthroughOrGroupYearGenerator"] is True
 
     def test_from_payload_defaults(self):
         payload = {"customGenerator": "DateTime"}
@@ -489,6 +516,7 @@ class TestDateTimeGeneratorMetadata:
         assert metadata.apply_constant_shift_to_document is False
         assert metadata.metadata.left_shift_in_days == -7
         assert metadata.metadata.right_shift_in_days == 7
+        assert metadata.use_clear_date_and_passthrough_or_group_year_generator is False
 
     def test_from_payload_with_values(self):
         payload = {
@@ -502,7 +530,8 @@ class TestDateTimeGeneratorMetadata:
                 "leftShiftInDays": -100,
                 "rightShiftInDays": 100,
                 "swaps": {"inner": "swap"}
-            }
+            },
+            "useClearDateAndPassthroughOrGroupYearGenerator": True
         }
         metadata = DateTimeGeneratorMetadata.from_payload(payload)
 
@@ -515,6 +544,7 @@ class TestDateTimeGeneratorMetadata:
         assert metadata.metadata.left_shift_in_days == -100
         assert metadata.metadata.right_shift_in_days == 100
         assert metadata.metadata.swaps == {"inner": "swap"}
+        assert metadata.use_clear_date_and_passthrough_or_group_year_generator is True
 
     def test_from_payload_invalid_generator_raises(self):
         payload = {"customGenerator": "Name"}
@@ -534,7 +564,8 @@ class TestDateTimeGeneratorMetadata:
             additional_date_formats=["format1", "format2"],
             apply_constant_shift_to_document=True,
             metadata=ts_metadata,
-            swaps={"outer": "swap"}
+            swaps={"outer": "swap"},
+            use_clear_date_and_passthrough_or_group_year_generator=True
         )
         payload = original.to_payload()
         payload["customGenerator"] = payload["customGenerator"].value
@@ -549,6 +580,7 @@ class TestDateTimeGeneratorMetadata:
         assert restored.metadata.left_shift_in_days == original.metadata.left_shift_in_days
         assert restored.metadata.right_shift_in_days == original.metadata.right_shift_in_days
         assert restored.metadata.swaps == original.metadata.swaps
+        assert restored.use_clear_date_and_passthrough_or_group_year_generator == original.use_clear_date_and_passthrough_or_group_year_generator
 
 
 class TestPersonAgeGeneratorMetadata:
@@ -562,6 +594,7 @@ class TestPersonAgeGeneratorMetadata:
         assert payload["scrambleUnrecognizedDates"] is True
         assert "metadata" in payload
         assert payload["metadata"]["ageShiftInYears"] == 7
+        assert payload["usePassthroughOrGroupAgeGenerator"] is False
 
     def test_to_payload_with_values(self):
         age_metadata = AgeShiftMetadata(age_shift_in_years=15)
@@ -569,7 +602,8 @@ class TestPersonAgeGeneratorMetadata:
             generator_version=GeneratorVersion.V2,
             scramble_unrecognized_dates=False,
             metadata=age_metadata,
-            swaps={"30": "35"}
+            swaps={"30": "35"},
+            use_passthrough_or_group_age_generator=True
         )
         payload = metadata.to_payload()
 
@@ -578,6 +612,7 @@ class TestPersonAgeGeneratorMetadata:
         assert payload["swaps"] == {"30": "35"}
         assert payload["scrambleUnrecognizedDates"] is False
         assert payload["metadata"]["ageShiftInYears"] == 15
+        assert payload["usePassthroughOrGroupAgeGenerator"] is True
 
     def test_from_payload_defaults(self):
         payload = {"customGenerator": "PersonAge"}
@@ -588,6 +623,7 @@ class TestPersonAgeGeneratorMetadata:
         assert metadata.swaps == {}
         assert metadata.scramble_unrecognized_dates is True
         assert metadata.metadata.age_shift_in_years == 7
+        assert metadata.use_passthrough_or_group_age_generator is False
 
     def test_from_payload_with_values(self):
         payload = {
@@ -597,7 +633,8 @@ class TestPersonAgeGeneratorMetadata:
             "scrambleUnrecognizedDates": False,
             "metadata": {
                 "ageShiftInYears": 25
-            }
+            },
+            "usePassthroughOrGroupAgeGenerator": True
         }
         metadata = PersonAgeGeneratorMetadata.from_payload(payload)
 
@@ -606,6 +643,7 @@ class TestPersonAgeGeneratorMetadata:
         assert metadata.swaps == {"age1": "age2"}
         assert metadata.scramble_unrecognized_dates is False
         assert metadata.metadata.age_shift_in_years == 25
+        assert metadata.use_passthrough_or_group_age_generator is True
 
     def test_from_payload_invalid_generator_raises(self):
         payload = {"customGenerator": "DateTime"}
@@ -619,7 +657,8 @@ class TestPersonAgeGeneratorMetadata:
             generator_version=GeneratorVersion.V2,
             scramble_unrecognized_dates=False,
             metadata=age_metadata,
-            swaps={"swap1": "swap2"}
+            swaps={"swap1": "swap2"},
+            use_passthrough_or_group_age_generator=True
         )
         payload = original.to_payload()
         payload["customGenerator"] = payload["customGenerator"].value
@@ -630,6 +669,7 @@ class TestPersonAgeGeneratorMetadata:
         assert restored.swaps == original.swaps
         assert restored.scramble_unrecognized_dates == original.scramble_unrecognized_dates
         assert restored.metadata.age_shift_in_years == original.metadata.age_shift_in_years
+        assert restored.use_passthrough_or_group_age_generator == original.use_passthrough_or_group_age_generator
 
 
 class TestTimestampShiftMetadata:

--- a/tests/tests/metadata_tests/test_payload_serialization.py
+++ b/tests/tests/metadata_tests/test_payload_serialization.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from tonic_textual.classes.generator_metadata.base_metadata import BaseMetadata
 from tonic_textual.classes.generator_metadata.name_generator_metadata import NameGeneratorMetadata
@@ -75,6 +77,28 @@ class TestBaseMetadata:
         assert restored.generator_version == original.generator_version
         assert restored.swaps == original.swaps
         assert restored.constant_value == original.constant_value
+
+    @pytest.mark.parametrize("json_value, expected_value", [
+        ("STATIC", "STATIC"),
+        ("bob", "bob"),
+        (1, "1"),
+        (1.0, "1.0"),
+        (None, None),
+        (True, "True"),
+        (False, "False"),
+    ] )
+    def test_can_deserialize_bare_values_for_constant_value(self, json_value: Any, expected_value: str | None):
+        payload = {
+            "customGenerator": "Name",
+            "generatorVersion": GeneratorVersion.V2,
+            "swaps": {"key": "value"},
+            "constantValue": json_value
+        }
+        metadata = BaseMetadata.from_payload(payload)
+
+        assert metadata.constant_value == expected_value
+
+
 
 
 class TestNameGeneratorMetadata:
@@ -825,3 +849,23 @@ class TestAgeShiftMetadata:
         restored = AgeShiftMetadata.from_payload(payload)
 
         assert restored.age_shift_in_years == original.age_shift_in_years
+
+    @pytest.mark.parametrize("json_value, expected_value", [
+        ("STATIC", "STATIC"),
+        ("bob", "bob"),
+        (1, "1"),
+        (1.0, "1.0"),
+        (None, None),
+        (True, "True"),
+        (False, "False"),
+    ])
+    def test_can_deserialize_bare_values_for_constant_value(self, json_value: Any, expected_value: str | None):
+        payload = {
+            "customGenerator": "Name",
+            "generatorVersion": GeneratorVersion.V2,
+            "swaps": {"key": "value"},
+            "constantValue": json_value
+        }
+        metadata = BaseMetadata.from_payload(payload)
+
+        assert metadata.constant_value == expected_value

--- a/tests/tests/metadata_tests/test_person_age_generator_metadata_json.py
+++ b/tests/tests/metadata_tests/test_person_age_generator_metadata_json.py
@@ -14,7 +14,8 @@ class TestPersonAgeGeneratorMetadataJsonSerialization:
             generator_version=GeneratorVersion.V2,
             scramble_unrecognized_dates=False,
             metadata=age_metadata,
-            swaps={"30": "35"}
+            swaps={"30": "35"},
+            use_passthrough_or_group_age_generator=True
         )
         json_str = json.dumps(metadata)
 
@@ -25,6 +26,7 @@ class TestPersonAgeGeneratorMetadataJsonSerialization:
         assert parsed["scrambleUnrecognizedDates"] is False
         assert parsed["metadata"]["ageShiftInYears"] == 15
         assert parsed["swaps"] == {"30": "35"}
+        assert parsed["usePassthroughOrGroupAgeGenerator"] is True
 
     def test_json_includes_type_field(self):
         """Serialized JSON should include _type for deserialization."""
@@ -46,6 +48,7 @@ class TestPersonAgeGeneratorMetadataJsonSerialization:
         assert restored.scramble_unrecognized_dates == original.scramble_unrecognized_dates
         assert restored.metadata.age_shift_in_years == original.metadata.age_shift_in_years
         assert restored.swaps == original.swaps
+        assert restored.use_passthrough_or_group_age_generator == False
 
     def test_json_roundtrip_with_custom_values(self):
         """Round-trip serialization preserves custom values."""
@@ -54,7 +57,8 @@ class TestPersonAgeGeneratorMetadataJsonSerialization:
             generator_version=GeneratorVersion.V2,
             scramble_unrecognized_dates=False,
             metadata=age_metadata,
-            swaps={"age1": "age2"}
+            swaps={"age1": "age2"},
+            use_passthrough_or_group_age_generator=True
         )
         json_str = json.dumps(original)
         parsed = json.loads(json_str)
@@ -65,6 +69,7 @@ class TestPersonAgeGeneratorMetadataJsonSerialization:
         assert restored.scramble_unrecognized_dates is False
         assert restored.metadata.age_shift_in_years == 25
         assert restored.swaps == {"age1": "age2"}
+        assert restored.use_passthrough_or_group_age_generator is True
 
     def test_attribute_access_works(self):
         """Property-based attribute access should work."""
@@ -79,9 +84,12 @@ class TestPersonAgeGeneratorMetadataJsonSerialization:
         metadata = PersonAgeGeneratorMetadata()
         new_age_metadata = AgeShiftMetadata(age_shift_in_years=50)
         metadata.metadata = new_age_metadata
+        metadata.use_passthrough_or_group_age_generator = True
 
         assert metadata.metadata.age_shift_in_years == 50
         assert metadata["metadata"]["ageShiftInYears"] == 50
+        assert metadata.use_passthrough_or_group_age_generator is True
+        assert metadata["usePassthroughOrGroupAgeGenerator"] is True
 
     def test_dict_access_works(self):
         """Direct dict access should work."""

--- a/tests/tests/metadata_tests/test_person_age_generator_metadata_json.py
+++ b/tests/tests/metadata_tests/test_person_age_generator_metadata_json.py
@@ -48,7 +48,7 @@ class TestPersonAgeGeneratorMetadataJsonSerialization:
         assert restored.scramble_unrecognized_dates == original.scramble_unrecognized_dates
         assert restored.metadata.age_shift_in_years == original.metadata.age_shift_in_years
         assert restored.swaps == original.swaps
-        assert restored.use_passthrough_or_group_age_generator == False
+        assert restored.use_passthrough_or_group_age_generator is False
 
     def test_json_roundtrip_with_custom_values(self):
         """Round-trip serialization preserves custom values."""

--- a/tonic_textual/classes/generator_metadata/base_date_time_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/base_date_time_generator_metadata.py
@@ -25,12 +25,14 @@ class BaseDateTimeGeneratorMetadata(BaseMetadata):
             custom_generator: Optional[GeneratorType] = None,
             generator_version: GeneratorVersion = GeneratorVersion.V1,
             scramble_unrecognized_dates: bool = True,
-            swaps: Optional[Dict[str,str]] = {}
+            swaps: Optional[Dict[str,str]] = {},
+            constant_value: Optional[str] = None,
     ):
         super().__init__(
             custom_generator=custom_generator,
             generator_version=generator_version,
-            swaps=swaps
+            swaps=swaps,
+            constant_value=constant_value
         )
         self["scrambleUnrecognizedDates"] = scramble_unrecognized_dates
 
@@ -53,7 +55,8 @@ class BaseDateTimeGeneratorMetadata(BaseMetadata):
             custom_generator=base_metadata.custom_generator,
             generator_version=base_metadata.generator_version,
             swaps=base_metadata.swaps,
-            scramble_unrecognized_dates=payload.get("scrambleUnrecognizedDates", True)
+            scramble_unrecognized_dates=payload.get("scrambleUnrecognizedDates", True),
+            constant_value=base_metadata.constant_value
         )
 
 default_base_date_time_generator_metadata = BaseDateTimeGeneratorMetadata()

--- a/tonic_textual/classes/generator_metadata/base_metadata.py
+++ b/tonic_textual/classes/generator_metadata/base_metadata.py
@@ -100,7 +100,7 @@ class BaseMetadata(dict):
             custom_generator=custom_generator,
             generator_version=generator_version,
             swaps=swaps,
-            constant_value=constant_value
+            constant_value=str(constant_value) if constant_value is not None else None
         )
 
 default_base_metadata = BaseMetadata()

--- a/tonic_textual/classes/generator_metadata/base_metadata.py
+++ b/tonic_textual/classes/generator_metadata/base_metadata.py
@@ -39,7 +39,7 @@ class BaseMetadata(dict):
         self["customGenerator"] = custom_generator
         self["generatorVersion"] = generator_version
         self["swaps"] = swaps if swaps is not None else {}
-        self["constant_value"] = constant_value
+        self["constantValue"] = constant_value
 
     @property
     def custom_generator(self) -> Optional[GeneratorType]:
@@ -67,11 +67,11 @@ class BaseMetadata(dict):
 
     @property
     def constant_value(self) -> Optional[str]:
-        return self["constant_value"]
+        return self["constantValue"]
 
     @constant_value.setter
     def constant_value(self, value: Optional[str]):
-        self["constant_value"] = value
+        self["constantValue"] = value
 
     def to_payload(self) -> Dict:
         return dict(self)
@@ -94,7 +94,7 @@ class BaseMetadata(dict):
 
         swaps = payload.get("swaps", {})
 
-        constant_value = payload.get("constant_value")
+        constant_value = payload.get("constantValue")
 
         return BaseMetadata(
             custom_generator=custom_generator,

--- a/tonic_textual/classes/generator_metadata/base_metadata.py
+++ b/tonic_textual/classes/generator_metadata/base_metadata.py
@@ -22,19 +22,24 @@ class BaseMetadata(dict):
         A dictionary of explicit replacement mappings. When a detected value
         matches a key in the dictionary, the corresponding value is used as
         the synthesized replacement instead of a generated one.
+    constant_value : str, optional
+        A string value that will be used as the replacement, when not ``None``
+        and there is no matching source value in ``swaps``.
     """
 
     def __init__(
             self,
             custom_generator: Optional[GeneratorType] = None,
             generator_version: GeneratorVersion = GeneratorVersion.V1,
-            swaps: Optional[Dict[str,str]] = {}
+            swaps: Optional[Dict[str,str]] = {},
+            constant_value: Optional[str] = None,
     ):
         super().__init__()
         self["_type"] = self.__class__.__name__
         self["customGenerator"] = custom_generator
         self["generatorVersion"] = generator_version
         self["swaps"] = swaps if swaps is not None else {}
+        self["constant_value"] = constant_value
 
     @property
     def custom_generator(self) -> Optional[GeneratorType]:
@@ -60,6 +65,14 @@ class BaseMetadata(dict):
     def swaps(self, value: Dict[str, str]):
         self["swaps"] = value if value is not None else {}
 
+    @property
+    def constant_value(self) -> Optional[str]:
+        return self["constant_value"]
+
+    @constant_value.setter
+    def constant_value(self, value: Optional[str]):
+        self["constant_value"] = value
+
     def to_payload(self) -> Dict:
         return dict(self)
 
@@ -81,10 +94,13 @@ class BaseMetadata(dict):
 
         swaps = payload.get("swaps", {})
 
+        constant_value = payload.get("constant_value")
+
         return BaseMetadata(
             custom_generator=custom_generator,
             generator_version=generator_version,
-            swaps=swaps
+            swaps=swaps,
+            constant_value=constant_value
         )
 
 default_base_metadata = BaseMetadata()

--- a/tonic_textual/classes/generator_metadata/date_time_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/date_time_generator_metadata.py
@@ -26,6 +26,11 @@ class DateTimeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
         When ``True``, all dates within the same document are shifted by
         the same random offset. This preserves relative time differences
         between dates. Default is ``False``.
+    use_clear_date_and_passthrough_or_group_year_generator: bool
+        When ``True`` sets the date to January 1st and if the year is less than 90 years ago, passes through the year.
+        Otherwise, sets the year to the current year - 90.
+        When ``False`` it has no effect.
+        Default is ``False``.
     metadata : TimestampShiftMetadata
         Configuration for the date shift range. By default dates shift by
         -7 to +7 days.
@@ -37,6 +42,7 @@ class DateTimeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
             scramble_unrecognized_dates: bool = True,
             additional_date_formats: List[str] = list(),
             apply_constant_shift_to_document: bool = False,
+            use_clear_date_and_passthrough_or_group_year_generator: bool = False,
             metadata: TimestampShiftMetadata = None,
             swaps: Optional[Dict[str,str]] = {},
             constant_value: Optional[str] = None,
@@ -53,6 +59,7 @@ class DateTimeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
         self["metadata"] = metadata
         self["additionalDateFormats"] = additional_date_formats
         self["applyConstantShiftToDocument"] = apply_constant_shift_to_document
+        self["useClearDateAndPassthroughOrGroupYearGenerator"] = use_clear_date_and_passthrough_or_group_year_generator
 
     @property
     def metadata(self) -> TimestampShiftMetadata:
@@ -78,6 +85,14 @@ class DateTimeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
     def apply_constant_shift_to_document(self, value: bool):
         self["applyConstantShiftToDocument"] = value
 
+    @property
+    def use_clear_date_and_passthrough_or_group_year_generator(self) -> bool:
+        return self["useClearDateAndPassthroughOrGroupYearGenerator"]
+
+    @use_clear_date_and_passthrough_or_group_year_generator.setter
+    def use_clear_date_and_passthrough_or_group_year_generator(self, value: bool):
+        self["useClearDateAndPassthroughOrGroupYearGenerator"] = value
+
     def to_payload(self) -> Dict:
         return dict(self)
 
@@ -99,6 +114,7 @@ class DateTimeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
             scramble_unrecognized_dates=base_metadata.scramble_unrecognized_dates,
             additional_date_formats=payload.get("additionalDateFormats", []),
             apply_constant_shift_to_document=payload.get("applyConstantShiftToDocument", False),
+            use_clear_date_and_passthrough_or_group_year_generator=payload.get("useClearDateAndPassthroughOrGroupYearGenerator", False),
             metadata=ts_metadata,
             swaps=base_metadata.swaps,
             constant_value=base_metadata.constant_value

--- a/tonic_textual/classes/generator_metadata/date_time_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/date_time_generator_metadata.py
@@ -38,13 +38,15 @@ class DateTimeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
             additional_date_formats: List[str] = list(),
             apply_constant_shift_to_document: bool = False,
             metadata: TimestampShiftMetadata = None,
-            swaps: Optional[Dict[str,str]] = {}
+            swaps: Optional[Dict[str,str]] = {},
+            constant_value: Optional[str] = None,
     ):
         super().__init__(
             custom_generator=GeneratorType.DateTime,
             generator_version=generator_version,
             scramble_unrecognized_dates=scramble_unrecognized_dates,
-            swaps=swaps
+            swaps=swaps,
+            constant_value=constant_value
         )
         if metadata is None:
             metadata = TimestampShiftMetadata()
@@ -98,7 +100,8 @@ class DateTimeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
             additional_date_formats=payload.get("additionalDateFormats", []),
             apply_constant_shift_to_document=payload.get("applyConstantShiftToDocument", False),
             metadata=ts_metadata,
-            swaps=base_metadata.swaps
+            swaps=base_metadata.swaps,
+            constant_value=base_metadata.constant_value
         )
 
 default_date_time_generator_metadata = DateTimeGeneratorMetadata()

--- a/tonic_textual/classes/generator_metadata/email_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/email_generator_metadata.py
@@ -23,12 +23,14 @@ class EmailGeneratorMetadata(BaseMetadata):
             self,
             generator_version: GeneratorVersion = GeneratorVersion.V1,
             preserve_domain: bool = False,
-            swaps: Optional[Dict[str,str]] = {}
+            swaps: Optional[Dict[str,str]] = {},
+            constant_value: Optional[str] = None,
     ):
         super().__init__(
                 custom_generator=GeneratorType.Email,
                 generator_version=generator_version,
-                swaps=swaps
+                swaps=swaps,
+                constant_value=constant_value
         )
         self["preserveDomain"] = preserve_domain
 
@@ -56,7 +58,8 @@ class EmailGeneratorMetadata(BaseMetadata):
         return EmailGeneratorMetadata(
             generator_version=base_metadata.generator_version,
             preserve_domain=payload.get("preserveDomain", False),
-            swaps=base_metadata.swaps
+            swaps=base_metadata.swaps,
+            constant_value=base_metadata.constant_value
         )
 
 default_email_generator_metadata = EmailGeneratorMetadata()

--- a/tonic_textual/classes/generator_metadata/hipaa_address_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/hipaa_address_generator_metadata.py
@@ -25,6 +25,12 @@ class HipaaAddressGeneratorMetadata(BaseMetadata):
     realistic_synthetic_values : bool
         When ``True``, generates realistic-looking synthetic address values.
         Default is ``True``.
+    use_three_digit_zips : bool
+        When ``True`` zip codes are always truncated to three digits.
+        Default is ``False``
+    replace_foreign_zip_codes_with_zeros : bool
+        When ``True`` foreign zip codes become all zeros
+        Default is ``False``
     """
 
     def __init__(
@@ -35,6 +41,8 @@ class HipaaAddressGeneratorMetadata(BaseMetadata):
             realistic_synthetic_values: bool = True,
             swaps: Optional[Dict[str,str]] = {},
             constant_value: Optional[str] = None,
+            use_three_digit_zips: bool = False,
+            replace_foreign_zip_codes_with_zeros: bool = False,
     ):
         super().__init__(
             custom_generator=GeneratorType.HipaaAddressGenerator,
@@ -45,6 +53,8 @@ class HipaaAddressGeneratorMetadata(BaseMetadata):
         self["useNonHipaaAddressGenerator"] = use_non_hipaa_address_generator
         self["replaceTruncatedZerosInZipCode"] = replace_truncated_zeros_in_zip_code
         self["realisticSyntheticValues"] = realistic_synthetic_values
+        self["useThreeDigitZips"] = use_three_digit_zips
+        self["replaceForeignZipCodesWithZeros"] = replace_foreign_zip_codes_with_zeros
 
     @property
     def use_non_hipaa_address_generator(self) -> bool:
@@ -70,6 +80,22 @@ class HipaaAddressGeneratorMetadata(BaseMetadata):
     def realistic_synthetic_values(self, value: bool):
         self["realisticSyntheticValues"] = value
 
+    @property
+    def use_three_digit_zips(self) -> bool:
+        return self["useThreeDigitZips"]
+
+    @use_three_digit_zips.setter
+    def use_three_digit_zips(self, value: bool):
+        self["useThreeDigitZips"] = value
+
+    @property
+    def replace_foreign_zip_codes_with_zeros(self) -> bool:
+        return self["replaceForeignZipCodesWithZeros"]
+
+    @replace_foreign_zip_codes_with_zeros.setter
+    def replace_foreign_zip_codes_with_zeros(self, value: bool):
+        self["replaceForeignZipCodesWithZeros"] = value
+
     def to_payload(self) -> Dict:
         return dict(self)
 
@@ -89,7 +115,9 @@ class HipaaAddressGeneratorMetadata(BaseMetadata):
             replace_truncated_zeros_in_zip_code=payload.get("replaceTruncatedZerosInZipCode", True),
             realistic_synthetic_values=payload.get("realisticSyntheticValues", True),
             swaps=base_metadata.swaps,
-            constant_value=base_metadata.constant_value
+            constant_value=base_metadata.constant_value,
+            use_three_digit_zips=payload.get("useThreeDigitZips", False),
+            replace_foreign_zip_codes_with_zeros=payload.get("replaceForeignZipCodesWithZeros", False)
         )
 
 default_hipaa_address_generator_metadata = HipaaAddressGeneratorMetadata()

--- a/tonic_textual/classes/generator_metadata/hipaa_address_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/hipaa_address_generator_metadata.py
@@ -33,12 +33,14 @@ class HipaaAddressGeneratorMetadata(BaseMetadata):
             use_non_hipaa_address_generator: bool = False,
             replace_truncated_zeros_in_zip_code: bool = True,
             realistic_synthetic_values: bool = True,
-            swaps: Optional[Dict[str,str]] = {}
+            swaps: Optional[Dict[str,str]] = {},
+            constant_value: Optional[str] = None,
     ):
         super().__init__(
             custom_generator=GeneratorType.HipaaAddressGenerator,
             generator_version=generator_version,
-            swaps=swaps
+            swaps=swaps,
+            constant_value=constant_value
         )
         self["useNonHipaaAddressGenerator"] = use_non_hipaa_address_generator
         self["replaceTruncatedZerosInZipCode"] = replace_truncated_zeros_in_zip_code
@@ -86,7 +88,8 @@ class HipaaAddressGeneratorMetadata(BaseMetadata):
             use_non_hipaa_address_generator=payload.get("useNonHipaaAddressGenerator", False),
             replace_truncated_zeros_in_zip_code=payload.get("replaceTruncatedZerosInZipCode", True),
             realistic_synthetic_values=payload.get("realisticSyntheticValues", True),
-            swaps=base_metadata.swaps
+            swaps=base_metadata.swaps,
+            constant_value=base_metadata.constant_value
         )
 
 default_hipaa_address_generator_metadata = HipaaAddressGeneratorMetadata()

--- a/tonic_textual/classes/generator_metadata/name_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/name_generator_metadata.py
@@ -28,12 +28,14 @@ class NameGeneratorMetadata(BaseMetadata):
             generator_version: GeneratorVersion = GeneratorVersion.V1,
             is_consistency_case_sensitive: bool = False,
             preserve_gender: bool = False,
-            swaps: Optional[Dict[str,str]] = {}
+            swaps: Optional[Dict[str,str]] = {},
+            constant_value: Optional[str] = None,
     ):
         super().__init__(
                 custom_generator=GeneratorType.Name,
                 generator_version=generator_version,
-                swaps=swaps
+                swaps=swaps,
+                constant_value=constant_value
         )
         self["isConsistencyCaseSensitive"] = is_consistency_case_sensitive
         self["preserveGender"] = preserve_gender
@@ -71,7 +73,8 @@ class NameGeneratorMetadata(BaseMetadata):
             generator_version=base_metadata.generator_version,
             is_consistency_case_sensitive=payload.get("isConsistencyCaseSensitive", False),
             preserve_gender=payload.get("preserveGender", False),
-            swaps=base_metadata.swaps
+            swaps=base_metadata.swaps,
+            constant_value=base_metadata.constant_value
         )
 
 default_name_generator_metadata = NameGeneratorMetadata()

--- a/tonic_textual/classes/generator_metadata/numeric_value_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/numeric_value_generator_metadata.py
@@ -22,12 +22,14 @@ class NumericValueGeneratorMetadata(BaseMetadata):
             self,
             generator_version: GeneratorVersion = GeneratorVersion.V1,
             use_oracle_integer_pk_generator: bool = False,
-            swaps: Optional[Dict[str,str]] = {}
+            swaps: Optional[Dict[str,str]] = {},
+            constant_value: Optional[str] = None,
     ):
         super().__init__(
             custom_generator=GeneratorType.NumericValue,
             generator_version=generator_version,
-            swaps=swaps
+            swaps=swaps,
+            constant_value=constant_value
         )
         self["useOracleIntegerPkGenerator"] = use_oracle_integer_pk_generator
 
@@ -55,7 +57,8 @@ class NumericValueGeneratorMetadata(BaseMetadata):
         return NumericValueGeneratorMetadata(
             generator_version=base_metadata.generator_version,
             use_oracle_integer_pk_generator=payload.get("useOracleIntegerPkGenerator", False),
-            swaps=base_metadata.swaps
+            swaps=base_metadata.swaps,
+            constant_value=base_metadata.constant_value
         )
 
 default_numeric_value_generator_metadata = NumericValueGeneratorMetadata()

--- a/tonic_textual/classes/generator_metadata/person_age_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/person_age_generator_metadata.py
@@ -22,7 +22,7 @@ class PersonAgeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
         7 years.
     use_passthrough_or_group_age_generator : bool
         When ``True`` passes through ages 89 or under. Changes other ages to "90+"
-        Default ``False``
+        Default is ``False``
     """
 
     def __init__(

--- a/tonic_textual/classes/generator_metadata/person_age_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/person_age_generator_metadata.py
@@ -20,6 +20,9 @@ class PersonAgeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
     metadata : AgeShiftMetadata
         Configuration for the age shift amount. By default, ages shift by
         7 years.
+    use_passthrough_or_group_age_generator : bool
+        When ``True`` passes through ages 89 or under. Changes other ages to "90+"
+        Default ``False``
     """
 
     def __init__(
@@ -29,6 +32,7 @@ class PersonAgeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
             metadata: AgeShiftMetadata = None,
             swaps: Optional[Dict[str,str]] = {},
             constant_value: Optional[str] = None,
+            use_passthrough_or_group_age_generator: bool = False,
     ):
         super().__init__(
             custom_generator=GeneratorType.PersonAge,
@@ -40,6 +44,7 @@ class PersonAgeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
         if metadata is None:
             metadata = AgeShiftMetadata()
         self["metadata"] = metadata
+        self["usePassthroughOrGroupAgeGenerator"] = use_passthrough_or_group_age_generator
 
     @property
     def metadata(self) -> AgeShiftMetadata:
@@ -48,6 +53,14 @@ class PersonAgeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
     @metadata.setter
     def metadata(self, value: AgeShiftMetadata):
         self["metadata"] = value
+
+    @property
+    def use_passthrough_or_group_age_generator(self) -> bool:
+        return self["usePassthroughOrGroupAgeGenerator"]
+
+    @use_passthrough_or_group_age_generator.setter
+    def use_passthrough_or_group_age_generator(self, value: bool):
+        self["usePassthroughOrGroupAgeGenerator"] = value
 
     def to_payload(self) -> Dict:
         return dict(self)
@@ -70,7 +83,8 @@ class PersonAgeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
             scramble_unrecognized_dates=base_metadata.scramble_unrecognized_dates,
             metadata=age_metadata,
             swaps=base_metadata.swaps,
-            constant_value=base_metadata.constant_value
+            constant_value=base_metadata.constant_value,
+            use_passthrough_or_group_age_generator=payload.get("usePassthroughOrGroupAgeGenerator", False)
         )
 
 default_person_age_generator_metadata = PersonAgeGeneratorMetadata()

--- a/tonic_textual/classes/generator_metadata/person_age_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/person_age_generator_metadata.py
@@ -27,13 +27,15 @@ class PersonAgeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
             generator_version: GeneratorVersion = GeneratorVersion.V1,
             scramble_unrecognized_dates: bool = True,
             metadata: AgeShiftMetadata = None,
-            swaps: Optional[Dict[str,str]] = {}
+            swaps: Optional[Dict[str,str]] = {},
+            constant_value: Optional[str] = None,
     ):
         super().__init__(
             custom_generator=GeneratorType.PersonAge,
             generator_version=generator_version,
             scramble_unrecognized_dates=scramble_unrecognized_dates,
-            swaps=swaps
+            swaps=swaps,
+            constant_value=constant_value
         )
         if metadata is None:
             metadata = AgeShiftMetadata()
@@ -67,7 +69,8 @@ class PersonAgeGeneratorMetadata(BaseDateTimeGeneratorMetadata):
             generator_version=base_metadata.generator_version,
             scramble_unrecognized_dates=base_metadata.scramble_unrecognized_dates,
             metadata=age_metadata,
-            swaps=base_metadata.swaps
+            swaps=base_metadata.swaps,
+            constant_value=base_metadata.constant_value
         )
 
 default_person_age_generator_metadata = PersonAgeGeneratorMetadata()

--- a/tonic_textual/classes/generator_metadata/phone_number_generator_metadata.py
+++ b/tonic_textual/classes/generator_metadata/phone_number_generator_metadata.py
@@ -27,12 +27,14 @@ class PhoneNumberGeneratorMetadata(BaseMetadata):
             generator_version: GeneratorVersion = GeneratorVersion.V1,
             use_us_phone_number_generator: bool = False,
             replace_invalid_numbers: bool = True,
-            swaps: Optional[Dict[str,str]] = {}
+            swaps: Optional[Dict[str,str]] = {},
+            constant_value: Optional[str] = None,
     ):
         super().__init__(
                 custom_generator=GeneratorType.PhoneNumber,
                 generator_version=generator_version,
-                swaps=swaps
+                swaps=swaps,
+                constant_value=constant_value
         )
         self["useUsPhoneNumberGenerator"] = use_us_phone_number_generator
         self["replaceInvalidNumbers"] = replace_invalid_numbers
@@ -70,7 +72,8 @@ class PhoneNumberGeneratorMetadata(BaseMetadata):
             generator_version=base_metadata.generator_version,
             use_us_phone_number_generator=payload.get("useUsPhoneNumberGenerator", False),
             replace_invalid_numbers=payload.get("replaceInvalidNumbers", True),
-            swaps=base_metadata.swaps
+            swaps=base_metadata.swaps,
+            constant_value=base_metadata.constant_value
         )
 
 default_phone_number_generator_metadata = PhoneNumberGeneratorMetadata()

--- a/tonic_textual/classes/generator_metadata/timestamp_shift_metadata.py
+++ b/tonic_textual/classes/generator_metadata/timestamp_shift_metadata.py
@@ -84,7 +84,7 @@ class TimestampShiftMetadata(BaseMetadata):
             right_shift_in_days=right_shift,
             time_stamp_shift_in_days=time_stamp_shift,
             swaps=swaps,
-            constant_value=constant_value
+            constant_value=str(constant_value) if constant_value is not None else None,
         )
 
 default_timestamp_shift_metadata = TimestampShiftMetadata()

--- a/tonic_textual/classes/generator_metadata/timestamp_shift_metadata.py
+++ b/tonic_textual/classes/generator_metadata/timestamp_shift_metadata.py
@@ -28,8 +28,10 @@ class TimestampShiftMetadata(BaseMetadata):
             left_shift_in_days: Optional[int] = -7,
             right_shift_in_days: Optional[int] = 7,
             time_stamp_shift_in_days: Optional[int] = None,
-            swaps: Optional[Dict[str,str]] = {}):
-        super().__init__(swaps=swaps)
+            swaps: Optional[Dict[str,str]] = {},
+            constant_value: Optional[str] = None,
+    ):
+        super().__init__(swaps=swaps, constant_value=constant_value)
 
         if time_stamp_shift_in_days is not None:
             warnings.warn("time_stamp_shift_in_days is being deprated and will not be supported past v285 of the product.")
@@ -72,6 +74,7 @@ class TimestampShiftMetadata(BaseMetadata):
     @staticmethod
     def from_payload(payload: Dict) -> "TimestampShiftMetadata":
         swaps = payload.get("swaps", {})
+        constant_value=payload.get("constant_value")
         left_shift = payload.get("leftShiftInDays", -7)
         right_shift = payload.get("rightShiftInDays", 7)
         time_stamp_shift = payload.get("timestampShiftInDays", None)
@@ -80,7 +83,8 @@ class TimestampShiftMetadata(BaseMetadata):
             left_shift_in_days=left_shift,
             right_shift_in_days=right_shift,
             time_stamp_shift_in_days=time_stamp_shift,
-            swaps=swaps
+            swaps=swaps,
+            constant_value=constant_value
         )
 
 default_timestamp_shift_metadata = TimestampShiftMetadata()


### PR DESCRIPTION
* Adds generator configuration for the following fields:
  * `constant_value`
  * `HipaaAddressGeneratorMetadata.use_three_digit_zips` 
  * `HipaaAddressGeneratorMetadata.replace_foreign_zip_codes_with_zeros` 
  * `PersonAgeGeneratorMetadata.use_passthrough_or_group_age_generator`
  * `DateTimeGeneratorMetadata.use_clear_date_and_passthrough_or_group_year_generator`
  
* Adds the fields to the documentation in `docs`