### PR TITLE
Update the emoji csv test file to pass LLM classification

### DIFF
--- a/tests/resources/emoji_file.csv
+++ b/tests/resources/emoji_file.csv
@@ -1,4 +1,5 @@
-text
-Today is my birthday. 🌮 Thanks 🙏 Adam🙏🏼! I live in Atlanta
-🙏🏼 Adam Kamor
-The remainder of this text is not interesting. It contains nothing sensitive and is just meant to add ascii characters so we do not incorrectly treat this file as binary. The remainder of this text is not interesting. It contains nothing sensitive and is just meant to add ascii characters so we do not incorrectly treat this file as binary. The remainder of this text is not interesting. It contains nothing sensitive and is just meant to add ascii characters so we do not incorrectly treat this file as binary. The remainder of this text is not interesting. It contains nothing sensitive and is just meant to add ascii characters so we do not incorrectly treat this file as binary. The remainder of this text is not interesting. It contains nothing sensitive and is just meant to add ascii characters so we do not incorrectly treat this file as binary. The remainder of this text is not interesting. It contains nothing sensitive and is just meant to add ascii characters so we do not incorrectly treat this file as binary. The remainder of this text is not interesting. It contains nothing sensitive and is just meant to add ascii characters so we do not incorrectly treat this file as binary.
+name, location, some_text
+Adam Kamor, Atlanta, Yesterday was my birthday
+Bob Johnson, Boston, There are no good 🌮 restaurants here
+🙏 Alice Smith 🙏, Texas, Tommorow is my birthday
+Charlie Brockton, Brockton, Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed semper porttitor orci in tempor diam viverra at. Nulla rutrum cursus eros id tincidunt. Nunc pellentesque leo at eros elementum id dictum sem suscipit. Pellentesque a elit non eros faucibus tristique nec eu metus. In maximus justo ut ex dapibus sit amet consectetur lectus posuere. Proin eleifend ac sapien ac sagittis. In bibendum lorem eu massa pretium iaculis.

--- a/tests/resources/emoji_file.csv
+++ b/tests/resources/emoji_file.csv
@@ -1,5 +1,5 @@
-name, location, some_text
-Adam Kamor, Atlanta, Yesterday was my birthday
-Bob Johnson, Boston, There are no good 🌮 restaurants here
-🙏 Alice Smith 🙏, Texas, Tommorow is my birthday
-Charlie Brockton, Brockton, Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed semper porttitor orci in tempor diam viverra at. Nulla rutrum cursus eros id tincidunt. Nunc pellentesque leo at eros elementum id dictum sem suscipit. Pellentesque a elit non eros faucibus tristique nec eu metus. In maximus justo ut ex dapibus sit amet consectetur lectus posuere. Proin eleifend ac sapien ac sagittis. In bibendum lorem eu massa pretium iaculis.
+text
+Adam Kamor is from Atlanta and yesterday was my birthday
+Bob Johnson is from Boston and there are no good 🌮 restaurants here
+🙏 Alice Smith 🙏 is from Texas and tommorow is my birthday
+Charlie Brockton is from Brockton and Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed semper porttitor orci in tempor diam viverra at. Nulla rutrum cursus eros id tincidunt. Nunc pellentesque leo at eros elementum id dictum sem suscipit. Pellentesque a elit non eros faucibus tristique nec eu metus. In maximus justo ut ex dapibus sit amet consectetur lectus posuere. Proin eleifend ac sapien ac sagittis. In bibendum lorem eu massa pretium iaculis.

--- a/tests/tests/redact_tests/test_redact_file.py
+++ b/tests/tests/redact_tests/test_redact_file.py
@@ -54,9 +54,7 @@ def test_redact_file_with_emoji(textual, filename, generator_default):
     original_content, output = perform_file_redaction(
         textual,
         filename,
-        generator_default=generator_default,
-        num_retries=120
-    )
+        generator_default=generator_default,    )
 
     check_redaction(
         original_content,

--- a/tests/tests/redact_tests/test_redact_file.py
+++ b/tests/tests/redact_tests/test_redact_file.py
@@ -55,7 +55,7 @@ def test_redact_file_with_emoji(textual, filename, generator_default):
         textual,
         filename,
         generator_default=generator_default,
-        num_retries=240
+        num_retries=120
     )
 
     check_redaction(

--- a/tests/tests/redact_tests/test_redact_file.py
+++ b/tests/tests/redact_tests/test_redact_file.py
@@ -54,7 +54,7 @@ def test_redact_file_with_emoji(textual, filename, generator_default):
     original_content, output = perform_file_redaction(
         textual,
         filename,
-        generator_default=generator_default
+        generator_default=generator_default,
     )
 
     check_redaction(

--- a/tests/tests/redact_tests/test_redact_file.py
+++ b/tests/tests/redact_tests/test_redact_file.py
@@ -55,6 +55,7 @@ def test_redact_file_with_emoji(textual, filename, generator_default):
         textual,
         filename,
         generator_default=generator_default,
+        num_retries=240
     )
 
     check_redaction(

--- a/tests/tests/redact_tests/test_redact_file.py
+++ b/tests/tests/redact_tests/test_redact_file.py
@@ -54,7 +54,8 @@ def test_redact_file_with_emoji(textual, filename, generator_default):
     original_content, output = perform_file_redaction(
         textual,
         filename,
-        generator_default=generator_default,    )
+        generator_default=generator_default
+    )
 
     check_redaction(
         original_content,


### PR DESCRIPTION
Updates the `emoji_file.csv` to remove the "It contains nothing sensitive" to prevent LLMs from marking the whole column as not sensitive. 

This seems to work better overall (against prod + env with `gemini-3.1-pro-preview` set as LLM) both are now redacting properly.