### PR TITLE
test(dataset_tests): make tests self-cleaning and remove global-list assertion

### DIFF
--- a/tests/tests/dataset_tests/conftest.py
+++ b/tests/tests/dataset_tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+@pytest.fixture
+def created_datasets(textual):
+    """Track datasets created during a test so they are cleaned up afterwards.
+
+    Tests should append each newly-created dataset name to the yielded list.
+    On teardown the fixture deletes every registered dataset, swallowing
+    per-dataset errors so a single failure does not mask others. This keeps
+    tests from leaking state into the shared backend used by the CI matrix.
+    """
+    names = []
+    yield names
+    for name in names:
+        try:
+            textual.delete_dataset(name)
+        except Exception:
+            pass

--- a/tests/tests/dataset_tests/test_dataset_lists.py
+++ b/tests/tests/dataset_tests/test_dataset_lists.py
@@ -5,8 +5,10 @@ from tests.utils.resource_utils import get_resource_path
 from tests.utils.dataset_utils import poll_until_file_rescans
 
 
-def test_upload_to_dataset(textual):
-    dataset = textual.create_dataset(str(uuid.uuid4()))
+def test_upload_to_dataset(textual, created_datasets):
+    ds_name = str(uuid.uuid4())
+    dataset = textual.create_dataset(ds_name)
+    created_datasets.append(ds_name)
 
     file_to_add = get_resource_path("simple_text_with_no_pii.txt")
     dataset.add_file(

--- a/tests/tests/dataset_tests/test_edit_dataset.py
+++ b/tests/tests/dataset_tests/test_edit_dataset.py
@@ -9,26 +9,32 @@ from tonic_textual.enums.pii_state import PiiState
 from tonic_textual.enums.pii_type import PiiType
 
 
-def test_edit_dataset(textual):
+def test_edit_dataset(textual, created_datasets):
     # name must be unique. if you already have a dataset, fetch it using get_dataset()
     name1 = str(uuid.uuid4())
     name2 = str(uuid.uuid4())
     dataset = textual.create_dataset(name1)
+    # Register both names: the dataset is renamed below, and per-name delete
+    # failures are tolerated, so registering both covers success and failure paths.
+    created_datasets.append(name1)
+    created_datasets.append(name2)
 
     dataset.edit(name=name2, label_allow_lists={"ORGANIZATION": ["that"]})
-    assert 'ORGANIZATION' in dataset.label_allow_lists 
+    assert 'ORGANIZATION' in dataset.label_allow_lists
     assert len(dataset.label_allow_lists) == 1
     assert isinstance(dataset.label_allow_lists['ORGANIZATION'], list)
 
     assert dataset.name == name2
 
 
-def test_edit_dataset_with_copied_metadata_and_config(textual):
+def test_edit_dataset_with_copied_metadata_and_config(textual, created_datasets):
     name1 = str(uuid.uuid4())
     name2 = str(uuid.uuid4())
 
     dataset1 = textual.create_dataset(name1)
+    created_datasets.append(name1)
     dataset2 = textual.create_dataset(name2)
+    created_datasets.append(name2)
 
     outbound_person_age_metadata = PersonAgeGeneratorMetadata(
         scramble_unrecognized_dates=False,
@@ -49,20 +55,23 @@ def test_edit_dataset_with_copied_metadata_and_config(textual):
     assert dataset2.generator_metadata[PiiType.PERSON_AGE.name].metadata.age_shift_in_years == 10
 
 
-def test_edit_datasetname_to_conflict(textual):
+def test_edit_datasetname_to_conflict(textual, created_datasets):
     # name must be unique. if you already have a dataset, fetch it using get_dataset()
     name1 = str(uuid.uuid4())
     name2 = str(uuid.uuid4())
     textual.create_dataset(name1)
+    created_datasets.append(name1)
     dataset2 = textual.create_dataset(name2)
+    created_datasets.append(name2)
 
     with pytest.raises(DatasetNameAlreadyExists):
         dataset2.edit(name=name1)
 
-def test_policies(textual):
+def test_policies(textual, created_datasets):
 
     name = 'policy-edit-'+str(uuid.uuid4())
     ds = textual.create_dataset(name)
+    created_datasets.append(name)
 
     assert ds.docx_image_policy==docx_image_policy.redact
     assert ds.docx_comment_policy==docx_comment_policy.remove

--- a/tests/tests/dataset_tests/test_get_dataset.py
+++ b/tests/tests/dataset_tests/test_get_dataset.py
@@ -15,34 +15,29 @@ from tests.utils.dataset_utils import (
     fetch_all_df_helper,
 )
 
-def test_get_all_datasets(textual: TextualNer):
+def test_get_all_datasets(textual: TextualNer, created_datasets):
     ds_name_one = str(uuid.uuid4()) + 'test-get-all-datasets-one'
     ds_one = textual.create_dataset(ds_name_one)
+    created_datasets.append(ds_name_one)
     ds_one.add_file(file_name = 'test-shelf.txt', file = create_file_stream("This is how I long my shelf: I do it with a long ruler."))
 
     ds_name_two = str(uuid.uuid4()) + 'test-get-all-datasets-two'
     ds_two = textual.create_dataset(ds_name_two)
+    created_datasets.append(ds_name_two)
     ds_two.add_file(file_name='test-gantry.txt', file=create_file_stream("Talking about how it's popping my bubbles; it's my gantry."))
 
     ds_all = textual.get_all_datasets()
 
-    assert len(ds_all) >= 2, "list of all datasets contains less than two items"
+    # Only assert on the two datasets this test created; the backend is shared
+    # across the Python-version matrix, so any global-length assertion is racy.
+    names = {ds.name for ds in ds_all}
+    assert ds_name_one in names, "first dataset did not appear in list of all datasets"
+    assert ds_name_two in names, "second dataset did not appear in list of all datasets"
 
-    one_found = False
-    two_found = False
-
-    for ds in ds_all:
-        if ds.name == ds_name_one:
-            one_found = True
-        if ds.name == ds_name_two:
-            two_found = True
-
-    assert one_found, "first dataset did not appear in list of all datasets"
-    assert two_found, "second dataset did not appear in list of all datasets"
-
-def test_get_dataset(textual: TextualNer):
+def test_get_dataset(textual: TextualNer, created_datasets):
     ds_name = str(uuid.uuid4()) + 'test-get-all-datasets-one'
     ds_out = textual.create_dataset(ds_name)
+    created_datasets.append(ds_name)
     ds_out.add_file(file_name = 'test-shelf.txt', file = create_file_stream("This is how I long my shelf: I do it with a long ruler."))
 
     person_age_metadata_out = PersonAgeGeneratorMetadata(

--- a/tests/tests/dataset_tests/test_get_dataset_files.py
+++ b/tests/tests/dataset_tests/test_get_dataset_files.py
@@ -6,9 +6,10 @@ import time
 import pytest
 import requests
 
-def test_processed_files_get_updated(textual: TextualNer):
+def test_processed_files_get_updated(textual: TextualNer, created_datasets):
     ds_name = str(uuid.uuid4()) + 'test-processed-files'
     ds = textual.create_dataset(ds_name)
+    created_datasets.append(ds_name)
     ds.add_file(file_name = 'test.txt', file = create_file_stream("My name is Adam. Again, my name is adam."))
 
     assert len(ds.files)==1, 'adding file updates list of dataset files'    
@@ -24,9 +25,10 @@ def test_processed_files_get_updated(textual: TextualNer):
         counter=counter+1
     assert success, "file should be processed and updated due to refetch"
 
-def test_processed_failed_files(textual: TextualNer):
+def test_processed_failed_files(textual: TextualNer, created_datasets):
     ds_name = str(uuid.uuid4())+'test-processed-files'
     ds = textual.create_dataset(ds_name)
+    created_datasets.append(ds_name)
 
     #invalid pdf
     with pytest.raises(requests.exceptions.RequestException) as exc:

--- a/tests/tests/dataset_tests/test_pii_occurrences.py
+++ b/tests/tests/dataset_tests/test_pii_occurrences.py
@@ -7,9 +7,10 @@ from tonic_textual.classes.datasetfile import DatasetFile
 from tonic_textual.enums.pii_type import PiiType
 from tonic_textual.redact_api import TextualNer
 
-def test_get_occurences(textual: TextualNer):
+def test_get_occurences(textual: TextualNer, created_datasets):
     ds_name = str(uuid.uuid4()) + 'test-occurences'
     ds = textual.create_dataset(ds_name)
+    created_datasets.append(ds_name)
     ds.add_file(file_name = 'file1.txt', file = create_file_stream("My name is John Smith. I live in Atlanta."))
     ds.add_file(file_name = 'file2.txt', file = create_file_stream("My name is Sally. I live in Georgia."))
 
@@ -48,7 +49,7 @@ def test_get_occurences(textual: TextualNer):
     assert len(file2_entities['LOCATION_STATE'])==1, 'unexpected location_state in file2'
     assert file2_entities['LOCATION_STATE'][0]['entity']=='Georgia'
 
-def test_occurences_pagination(textual: TextualNer):
+def test_occurences_pagination(textual: TextualNer, created_datasets):
     #we fetch 5 records at a time per entity, so lets create a file with 12 numeric values
     random_numbers = [random.randint(0, 1000) for _ in range(12)]
     lines = ['The number is ' + str(r) for r in random_numbers]
@@ -56,6 +57,7 @@ def test_occurences_pagination(textual: TextualNer):
 
     ds_name = str(uuid.uuid4()) + 'test-occurences-pagination'
     ds = textual.create_dataset(ds_name)
+    created_datasets.append(ds_name)
     ds.add_file(file_name = 'file.txt', file = create_file_stream(document))
 
     retries = 0

--- a/tests/tests/dataset_tests/test_upload_files_to_dataset.py
+++ b/tests/tests/dataset_tests/test_upload_files_to_dataset.py
@@ -6,9 +6,11 @@ from tests.utils.resource_utils import get_resource_path
 from tests.utils.dataset_utils import check_dataset_str
 
 
-def test_upload_to_dataset(textual):
+def test_upload_to_dataset(textual, created_datasets):
     # name must be unique. if you already have a dataset, fetch it using get_dataset()
-    dataset = textual.create_dataset(str(uuid.uuid4()))
+    ds_name = str(uuid.uuid4())
+    dataset = textual.create_dataset(ds_name)
+    created_datasets.append(ds_name)
 
     dataset_file1 = dataset.add_file(
         get_resource_path("simple_file.txt"), "simple_file.txt"
@@ -41,9 +43,11 @@ def test_upload_to_dataset(textual):
     
 
 
-def test_delete_file(textual):
+def test_delete_file(textual, created_datasets):
     # name must be unique. if you already have a dataset, fetch it using get_dataset()
-    dataset = textual.create_dataset(str(uuid.uuid4()))
+    ds_name = str(uuid.uuid4())
+    dataset = textual.create_dataset(ds_name)
+    created_datasets.append(ds_name)
 
     dataset.add_file(get_resource_path("simple_file.txt"), "simple_file.txt")
 
@@ -54,8 +58,10 @@ def test_delete_file(textual):
     assert len(dataset.files) == 0
 
 
-def test_add_file_to_dataset_argument_logic(textual):
-    dataset = textual.create_dataset(str(uuid.uuid4()))
+def test_add_file_to_dataset_argument_logic(textual, created_datasets):
+    ds_name = str(uuid.uuid4())
+    dataset = textual.create_dataset(ds_name)
+    created_datasets.append(ds_name)
 
     # ensure that if both file path and file are provided we throw exceptoin
     with pytest.raises(Exception) as e_info:


### PR DESCRIPTION
The Python SDK CI matrix (python-version: [3.9, 3.13]) runs both jobs against the same shared PRAPP backend with the same org/API key. This caused cross-matrix flakes in tests/tests/dataset_tests/, most visibly test_get_all_datasets, which:

  1. Created two datasets without ever deleting them, leaking state into subsequent runs of the other matrix entry.
  2. Asserted len(get_all_datasets()) >= 2, which is a global-list assertion that depends on backend state outside the test's control and can also race with the SDK's internal N+1 list -> get_dataset_by_name loop (a parallel deletion can surface as a 404 mid-loop).

This change:

- Adds tests/tests/dataset_tests/conftest.py with a function-scoped 'created_datasets' fixture: tests append each created dataset name to the yielded list, and the fixture deletes every registered name on teardown (best-effort per name, so a single failure does not mask others). This mirrors the create -> yield -> delete pattern already used by setup_dataset in tests/conftest.py.
- Drops the global len(ds_all) >= 2 assertion in test_get_all_datasets; it now only checks that the two UUID-named datasets it created appear in the result, which is what the test actually intends to verify.
- Wires the new fixture into every backend-touching test in dataset_tests/ that previously created datasets without teardown: test_dataset_lists, test_edit_dataset (all four tests, including the rename case where both pre- and post-rename names are registered), test_get_dataset (both tests), test_get_dataset_files (both tests), test_pii_occurrences (both tests), test_upload_files_to_dataset (all three tests). test_entity_mappings is unaffected (pure unit tests with a mocked client).

Out of scope (tracked separately): the underlying N+1 in tonic_textual/services/dataset.py::get_all_datasets, which is still race-prone against concurrent deletions even with this fix.