### PR TITLE
TN-57663 - Render retained Graph PDFs by document id

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,4 +7,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v1
         with:
+          version: "0.11.10"
           args: "check --target-version py37"

--- a/tests/tests/subject_graph_tests/test_render_pdf.py
+++ b/tests/tests/subject_graph_tests/test_render_pdf.py
@@ -1,0 +1,26 @@
+from tonic_textual.classes.subject_graph_collection import SubjectGraph
+
+
+class _PdfClient:
+    def __init__(self):
+        self.call = None
+
+    def http_get_file(self, url, session, params=None, additional_headers=None):
+        params = params or {}
+        additional_headers = additional_headers or {}
+        self.call = (url, params, additional_headers)
+        return b"%PDF-1.7\nsynthetic\n"
+
+
+def test_render_pdf_downloads_retained_source_by_document_id():
+    client = _PdfClient()
+    graph = SubjectGraph(client, id="graph-id")
+
+    content = graph.render_pdf("document-id", random_seed=42)
+
+    assert content.startswith(b"%PDF-")
+    assert client.call == (
+        "/api/graph/graph-id/documents/document-id/render-pdf",
+        {},
+        {"textual-random-seed": "42"},
+    )

--- a/tonic_textual/classes/subject_graph_collection.py
+++ b/tonic_textual/classes/subject_graph_collection.py
@@ -130,8 +130,9 @@ class SubjectGraph:
         """Ingests a PDF into the graph as a BACKGROUND job (the "PDF content informs the graph" path).
 
         Unlike :meth:`add_text`, PDF ingest is asynchronous: the server OCR-parses the PDF, detects
-        PII, detects V5 styles for every recognized word, and persists the source in private object
-        storage together with per-page mentions and geometry. This posts the bytes to
+        PII, detects V5 styles for the retained PII mentions (including later enrichment), and
+        persists the source in private object storage together with per-page mentions and geometry.
+        This posts the bytes to
         ``/api/graph/{id}/pdf`` and, when ``wait`` is True, blocks until the ingest job finishes.
         Re-posting the same ``document_id`` replaces the source, mentions, geometry, and styles.
 

--- a/tonic_textual/classes/subject_graph_collection.py
+++ b/tonic_textual/classes/subject_graph_collection.py
@@ -21,12 +21,11 @@ class SubjectGraph:
     """A standalone subject graph built by streaming text in, reconciling, and synthesizing.
 
     A ``SubjectGraph`` is the dataset-free unit of work for the ``/api/graph`` streaming API. Unlike
-    :class:`~tonic_textual.classes.subject_collection.SubjectCollection` (which is a dataset of
-    uploaded files), a graph has no files: you push raw text into it with :meth:`add_text` — a
-    synchronous, jobless call that detects entities and folds their mentions into the graph
-    immediately — then :meth:`reconcile` groups the mentions into canonical subjects and
-    :meth:`synthesize` fills the synthetic bundles over the whole graph. Once frozen, each ingested
-    document is read back with :meth:`render_document`.
+    :class:`~tonic_textual.classes.subject_collection.SubjectCollection`, it does not own a general
+    file collection: text is supplied again at render time, while standalone PDFs are retained in
+    private object storage so their V5-styled output can be rendered by document id. After ingest,
+    :meth:`reconcile` groups mentions into canonical subjects and :meth:`synthesize` fills the
+    synthetic bundles over the whole graph.
 
     The subject / relationship surface (:meth:`create_subject`, :meth:`add_relationship`,
     :meth:`merge_subjects`, :meth:`delete_relationship`, :meth:`get_subject_graph`) mirrors
@@ -131,10 +130,10 @@ class SubjectGraph:
         """Ingests a PDF into the graph as a BACKGROUND job (the "PDF content informs the graph" path).
 
         Unlike :meth:`add_text`, PDF ingest is asynchronous: the server OCR-parses the PDF, detects
-        PII, and persists per-page mentions plus each mention's page geometry (so the graph can later
-        drive coordinate-accurate redaction/synthesis of the PDF). This posts the bytes to
+        PII, detects V5 styles for every recognized word, and persists the source in private object
+        storage together with per-page mentions and geometry. This posts the bytes to
         ``/api/graph/{id}/pdf`` and, when ``wait`` is True, blocks until the ingest job finishes.
-        Re-posting the same ``document_id`` replaces that document's mentions + geometry.
+        Re-posting the same ``document_id`` replaces the source, mentions, geometry, and styles.
 
         Parameters
         ----------
@@ -497,6 +496,40 @@ class SubjectGraph:
         """
         response = self._render(document_id, text, random_seed)
         return response if isinstance(response, dict) else {"synthetic": response, "entities": []}
+
+    def render_pdf(
+        self,
+        document_id: str,
+        random_seed: Optional[int] = None,
+    ) -> bytes:
+        """Renders a retained standalone PDF from the frozen graph.
+
+        The original PDF was retained by :meth:`add_pdf`, so callers provide only its document id.
+        The server resolves the graph-wide synthetic values, applies their stored V5 font and placement
+        data, and returns the synthesized PDF bytes. Call :meth:`reconcile` and :meth:`synthesize`
+        first.
+
+        Parameters
+        ----------
+        document_id : str
+            The document id returned by :meth:`add_pdf`.
+        random_seed : Optional[int]
+            Optional seed override for any server-side fallback generation.
+
+        Returns
+        -------
+        bytes
+            The synthesized PDF.
+        """
+        headers = (
+            {"textual-random-seed": str(random_seed)} if random_seed is not None else {}
+        )
+        with requests.Session() as session:
+            return self.client.http_get_file(
+                f"/api/graph/{self.id}/documents/{document_id}/render-pdf",
+                session=session,
+                additional_headers=headers,
+            )
 
     def _render(self, document_id: str, text: str, random_seed: Optional[int]):
         headers = (

--- a/tonic_textual/subjects_api.py
+++ b/tonic_textual/subjects_api.py
@@ -1,7 +1,5 @@
 import os
-from time import sleep
 from typing import List, Optional
-from urllib.parse import urlencode
 from warnings import warn
 import requests
 

--- a/tonic_textual/subjects_api.py
+++ b/tonic_textual/subjects_api.py
@@ -61,10 +61,10 @@ class TextualSubjects:
     ) -> SubjectGraph:
         """Creates a subject graph — the dataset-free unit of the ``/api/graph`` streaming API.
 
-        Unlike a subject collection (a dataset of uploaded files), a graph holds no files: you
-        stream raw text into it with ``SubjectGraph.add_text`` (synchronous, jobless), then
-        ``reconcile`` / ``synthesize`` over the whole graph and read each document back with
-        ``render_document``.
+        Unlike a subject collection, a graph does not expose a general file collection. You can stream
+        raw text into it with ``SubjectGraph.add_text`` or upload standalone PDFs with
+        ``SubjectGraph.add_pdf``. PDF sources are retained privately for later V5 rendering through
+        ``SubjectGraph.render_pdf``; text remains caller-supplied at ``render_document`` time.
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary

- add `SubjectGraph.render_pdf(document_id)` over the retained-source Graph PDF render endpoint
- keep the random-seed request header contract covered while returning the rendered PDF bytes directly
- document the precise retained-PDF contract: V5 styles are stored only for initial PII mentions and mentions added by later Graph enrichment, not for every recognized word
- support the coordinated Solar and Protege pilot implementation listed below

## Test plan

- `PYTHONPATH=. pytest -q tests/tests/subject_graph_tests/test_render_pdf.py`
- GitHub `ruff` check passes on the latest branch head
- the Protege pilot real-corpus run rendered all 12 retained PDFs (825 pages); every output passes qpdf validation and preserves its source page count

Jira: https://tonic-ai.atlassian.net/browse/TN-57663

## Related branches and PRs

- Solar: `tn-57663-preserve-pdf-layout-in-graph-synthesis` — https://github.com/TonicAI/solar/pull/3424
- Textual Python SDK: `tn-57663-render-retained-graph-pdfs` — https://github.com/TonicAI/textual/pull/123
- Protege pilot: `tn-57663-use-retained-pdf-sources` — https://github.com/TonicAI/protege-pilot/pull/1


## Environment variables

No new environment variables are introduced by this SDK PR. Existing client configuration (`TONIC_TEXTUAL_API_KEY`, or an explicitly supplied API key and Graph base URL) is unchanged. S3 configuration belongs to the Solar Graph deployment, not the Python SDK.
