### PR TITLE
TN-57737 - Make Python SDK file downloads resilient to transient errors

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,4 +7,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v1
         with:
-          args: "check --target-version py37"
+          version: "0.11.10"
+          args: "check --target-version py39"

--- a/tests/tests/test_download_resilience.py
+++ b/tests/tests/test_download_resilience.py
@@ -108,6 +108,24 @@ def test_dataset_file_download_polls_not_ready_with_fixed_delay() -> None:
     assert [call.args[0] for call in sleep.call_args_list] == [2, 2]
 
 
+def test_dataset_file_download_starts_transient_backoff_after_not_ready_polls() -> None:
+    client = Mock(spec=HttpClient)
+    transient_response = _response(429, "capacity exhausted")
+    transient_error = requests.HTTPError(response=transient_response)
+    client.http_get_file.side_effect = [
+        FileNotReadyForDownload("not ready"),
+        FileNotReadyForDownload("not ready"),
+        transient_error,
+        b"redacted-pdf",
+    ]
+
+    with patch("tonic_textual.classes.datasetfile.sleep") as sleep:
+        result = _file(client).download(num_retries=4, wait_between_retries=3)
+
+    assert result == b"redacted-pdf"
+    assert [call.args[0] for call in sleep.call_args_list] == [3, 3, 3]
+
+
 def test_dataset_file_download_honors_retry_after() -> None:
     client = Mock(spec=HttpClient)
     transient_response = _response(

--- a/tests/tests/test_download_resilience.py
+++ b/tests/tests/test_download_resilience.py
@@ -6,7 +6,10 @@ import requests
 from tonic_textual import __version__
 from tonic_textual.classes.datasetfile import DatasetFile
 from tonic_textual.classes.httpclient import HttpClient
-from tonic_textual.classes.tonic_exception import TextualServerError
+from tonic_textual.classes.tonic_exception import (
+    FileNotReadyForDownload,
+    TextualServerError,
+)
 
 
 def _response(status_code: int, body: str, **headers: str) -> requests.Response:
@@ -32,10 +35,11 @@ def _file(client: HttpClient) -> DatasetFile:
     )
 
 
-def test_http_client_identifies_its_sdk_version() -> None:
+def test_http_client_preserves_attribution_and_identifies_its_sdk_version() -> None:
     client = HttpClient("https://textual.test", "api-key", verify=True)
 
-    assert client.headers["User-Agent"] == f"tonic-textual-python-sdk/{__version__}"
+    assert client.headers["User-Agent"] == "tonic-textual-python-sdk"
+    assert client.headers["X-Tonic-Textual-SDK-Version"] == __version__
 
 
 def test_http_get_file_preserves_non_json_server_error() -> None:
@@ -89,6 +93,21 @@ def test_dataset_file_download_retries_transient_http_errors(status_code: int) -
     sleep.assert_called_once_with(3)
 
 
+def test_dataset_file_download_polls_not_ready_with_fixed_delay() -> None:
+    client = Mock(spec=HttpClient)
+    client.http_get_file.side_effect = [
+        FileNotReadyForDownload("not ready"),
+        FileNotReadyForDownload("not ready"),
+        b"redacted-pdf",
+    ]
+
+    with patch("tonic_textual.classes.datasetfile.sleep") as sleep:
+        result = _file(client).download(num_retries=3, wait_between_retries=2)
+
+    assert result == b"redacted-pdf"
+    assert [call.args[0] for call in sleep.call_args_list] == [2, 2]
+
+
 def test_dataset_file_download_honors_retry_after() -> None:
     client = Mock(spec=HttpClient)
     transient_response = _response(
@@ -103,6 +122,34 @@ def test_dataset_file_download_honors_retry_after() -> None:
         _file(client).download(num_retries=2, wait_between_retries=3)
 
     sleep.assert_called_once_with(7)
+
+
+@pytest.mark.parametrize(
+    ("retry_after", "expected_delay"),
+    [
+        ("999999", 60),
+        ("1e309", 3),
+        ("nan", 3),
+        ("-1", 3),
+    ],
+)
+def test_dataset_file_download_bounds_retry_after(
+    retry_after: str,
+    expected_delay: int,
+) -> None:
+    client = Mock(spec=HttpClient)
+    transient_response = _response(
+        429,
+        "capacity exhausted",
+        **{"Retry-After": retry_after},
+    )
+    transient_error = requests.HTTPError(response=transient_response)
+    client.http_get_file.side_effect = [transient_error, b"redacted-pdf"]
+
+    with patch("tonic_textual.classes.datasetfile.sleep") as sleep:
+        _file(client).download(num_retries=2, wait_between_retries=3)
+
+    sleep.assert_called_once_with(expected_delay)
 
 
 def test_dataset_file_download_reraises_transient_error_after_backoff_budget() -> None:

--- a/tests/tests/test_download_resilience.py
+++ b/tests/tests/test_download_resilience.py
@@ -1,0 +1,142 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from tonic_textual import __version__
+from tonic_textual.classes.datasetfile import DatasetFile
+from tonic_textual.classes.httpclient import HttpClient
+from tonic_textual.classes.tonic_exception import TextualServerError
+
+
+def _response(status_code: int, body: str, **headers: str) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = body.encode("utf-8")
+    response.headers.update(headers)
+    response.url = "https://textual.test/download"
+    response.request = requests.Request("GET", response.url).prepare()
+    return response
+
+
+def _file(client: HttpClient) -> DatasetFile:
+    return DatasetFile(
+        client=client,
+        id="file-id",
+        dataset_id="dataset-id",
+        name="file.pdf",
+        num_rows=None,
+        num_columns=0,
+        processing_status="Completed",
+        processing_error=None,
+    )
+
+
+def test_http_client_identifies_its_sdk_version() -> None:
+    client = HttpClient("https://textual.test", "api-key", verify=True)
+
+    assert client.headers["User-Agent"] == f"tonic-textual-python-sdk/{__version__}"
+
+
+def test_http_get_file_preserves_non_json_server_error() -> None:
+    session = Mock(spec=requests.Session)
+    session.get.return_value = _response(
+        500,
+        "<html><h1>500 Internal Server Error</h1></html>",
+        **{"Content-Type": "text/html"},
+    )
+    client = HttpClient("https://textual.test", "api-key", verify=True)
+
+    with pytest.raises(TextualServerError, match="500 Internal Server Error"):
+        client.http_get_file("/download", session)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "requests_method"),
+    [
+        ("http_put", "put"),
+        ("http_patch", "patch"),
+        ("http_delete", "delete"),
+    ],
+)
+def test_http_mutation_preserves_non_json_server_error(
+    method_name: str,
+    requests_method: str,
+) -> None:
+    response = _response(500, "<html><h1>500 Internal Server Error</h1></html>")
+    client = HttpClient("https://textual.test", "api-key", verify=True)
+
+    with (
+        patch(f"tonic_textual.classes.httpclient.requests.{requests_method}", return_value=response),
+        pytest.raises(TextualServerError, match="500 Internal Server Error") as error,
+    ):
+        getattr(client, method_name)("/resource")
+
+    assert error.value.response is response
+
+
+@pytest.mark.parametrize("status_code", [429, 502, 503, 504])
+def test_dataset_file_download_retries_transient_http_errors(status_code: int) -> None:
+    client = Mock(spec=HttpClient)
+    transient_response = _response(status_code, "temporary upstream failure")
+    transient_error = requests.HTTPError(response=transient_response)
+    client.http_get_file.side_effect = [transient_error, b"redacted-pdf"]
+
+    with patch("tonic_textual.classes.datasetfile.sleep") as sleep:
+        result = _file(client).download(num_retries=2, wait_between_retries=3)
+
+    assert result == b"redacted-pdf"
+    sleep.assert_called_once_with(3)
+
+
+def test_dataset_file_download_honors_retry_after() -> None:
+    client = Mock(spec=HttpClient)
+    transient_response = _response(
+        429,
+        "capacity exhausted",
+        **{"Retry-After": "7"},
+    )
+    transient_error = requests.HTTPError(response=transient_response)
+    client.http_get_file.side_effect = [transient_error, b"redacted-pdf"]
+
+    with patch("tonic_textual.classes.datasetfile.sleep") as sleep:
+        _file(client).download(num_retries=2, wait_between_retries=3)
+
+    sleep.assert_called_once_with(7)
+
+
+def test_dataset_file_download_reraises_transient_error_after_backoff_budget() -> None:
+    client = Mock(spec=HttpClient)
+    transient_response = _response(504, "temporary upstream failure")
+    transient_error = requests.HTTPError(
+        "504 Server Error: Gateway Timeout",
+        response=transient_response,
+    )
+    client.http_get_file.side_effect = [
+        transient_error,
+        transient_error,
+        transient_error,
+    ]
+
+    with (
+        patch("tonic_textual.classes.datasetfile.sleep") as sleep,
+        pytest.raises(requests.HTTPError, match="Gateway Timeout"),
+    ):
+        _file(client).download(num_retries=3, wait_between_retries=2)
+
+    assert [call.args[0] for call in sleep.call_args_list] == [2, 4]
+
+
+def test_dataset_file_download_does_not_retry_permanent_server_error() -> None:
+    client = Mock(spec=HttpClient)
+    client.http_get_file.side_effect = TextualServerError(
+        {"error": "The PDF cannot be processed"}
+    )
+
+    with (
+        patch("tonic_textual.classes.datasetfile.sleep") as sleep,
+        pytest.raises(TextualServerError, match="PDF cannot be processed"),
+    ):
+        _file(client).download(num_retries=3, wait_between_retries=1)
+
+    sleep.assert_not_called()

--- a/tonic_textual/classes/datasetfile.py
+++ b/tonic_textual/classes/datasetfile.py
@@ -1,3 +1,4 @@
+import math
 from time import sleep
 from typing import Dict, List, Optional, Union
 
@@ -154,7 +155,8 @@ class DatasetFile:
             and 504) are retried. (The default value is 6)
 
         wait_between_retries: int = 10
-            The number of seconds to wait between retry attempts.
+            The fixed number of seconds to wait when a file is not ready. Transient
+            HTTP failures use this value as the initial exponential-backoff delay.
 
         Returns
         -------
@@ -166,6 +168,7 @@ class DatasetFile:
 
         last_error = None
         for attempt in range(1, num_retries + 1):
+            retry_delay = max(wait_between_retries, 0)
             try:
                 if random_seed is not None:
                     additional_headers = {"textual-random-seed": str(random_seed)}
@@ -184,9 +187,14 @@ class DatasetFile:
                 if not self._is_transient_download_error(error):
                     raise
                 last_error = error
+                retry_delay = self._transient_retry_delay(
+                    error,
+                    attempt,
+                    wait_between_retries,
+                )
 
             if attempt < num_retries:
-                sleep(self._retry_delay(last_error, attempt, wait_between_retries))
+                sleep(retry_delay)
 
         if isinstance(last_error, requests.exceptions.HTTPError):
             raise last_error
@@ -205,11 +213,11 @@ class DatasetFile:
             and error.response.status_code in cls._TRANSIENT_DOWNLOAD_STATUS_CODES
         )
 
-    # Compute bounded exponential backoff while honoring a numeric Retry-After header.
+    # Compute bounded exponential backoff while honoring a safe numeric Retry-After header.
     @classmethod
-    def _retry_delay(
+    def _transient_retry_delay(
         cls,
-        error: Exception,
+        error: requests.exceptions.HTTPError,
         attempt: int,
         wait_between_retries: int,
     ) -> float:
@@ -217,18 +225,23 @@ class DatasetFile:
             max(wait_between_retries, 0) * (2 ** (attempt - 1)),
             cls._MAX_RETRY_DELAY_SECONDS,
         )
-        if not isinstance(error, requests.exceptions.HTTPError):
-            return backoff
-
         response = error.response
         if response is None:
             return backoff
 
         retry_after = response.headers.get("Retry-After")
         try:
-            return max(backoff, float(retry_after))
+            retry_after_seconds = float(retry_after)
         except (TypeError, ValueError):
             return backoff
+
+        if not math.isfinite(retry_after_seconds) or retry_after_seconds < 0:
+            return backoff
+
+        return min(
+            max(backoff, retry_after_seconds),
+            cls._MAX_RETRY_DELAY_SECONDS,
+        )
 
 
     def get_entities(self, pii_types: Optional[List[Union[PiiType, str]]] = None) -> Dict[PiiType, List[NerRedactionApiModel]]:        

--- a/tonic_textual/classes/datasetfile.py
+++ b/tonic_textual/classes/datasetfile.py
@@ -167,6 +167,7 @@ class DatasetFile:
             raise ValueError("num_retries must be at least 1")
 
         last_error = None
+        transient_failure_count = 0
         for attempt in range(1, num_retries + 1):
             retry_delay = max(wait_between_retries, 0)
             try:
@@ -187,9 +188,10 @@ class DatasetFile:
                 if not self._is_transient_download_error(error):
                     raise
                 last_error = error
+                transient_failure_count += 1
                 retry_delay = self._transient_retry_delay(
                     error,
-                    attempt,
+                    transient_failure_count,
                     wait_between_retries,
                 )
 

--- a/tonic_textual/classes/datasetfile.py
+++ b/tonic_textual/classes/datasetfile.py
@@ -1,17 +1,28 @@
-import requests
 from time import sleep
-from typing import Optional, Dict, List, Union
+from typing import Dict, List, Optional, Union
 
-from tonic_textual.classes.common_api_responses.label_custom_list import LabelCustomList
-from tonic_textual.classes.common_api_responses.pii_occurences.ner_redaction_api_model import NerRedactionApiModel
-from tonic_textual.classes.common_api_responses.pii_occurences.ner_redaction_page_api_model import NerRedactionPageApiModel
-from tonic_textual.classes.common_api_responses.pii_occurences.paginated_pii_occurrence_response import PaginatedPiiOccurrenceResponse
-from tonic_textual.classes.common_api_responses.pii_occurences.pii_occurrence_response import PiiOccurrenceResponse
+import requests
+
+from tonic_textual.classes.common_api_responses.label_custom_list import (
+    LabelCustomList,
+)
+from tonic_textual.classes.common_api_responses.pii_occurences.ner_redaction_api_model import (
+    NerRedactionApiModel,
+)
+from tonic_textual.classes.common_api_responses.pii_occurences.ner_redaction_page_api_model import (
+    NerRedactionPageApiModel,
+)
+from tonic_textual.classes.common_api_responses.pii_occurences.paginated_pii_occurrence_response import (
+    PaginatedPiiOccurrenceResponse,
+)
+from tonic_textual.classes.common_api_responses.pii_occurences.pii_occurrence_response import (
+    PiiOccurrenceResponse,
+)
 from tonic_textual.classes.enums.file_redaction_policies import (
-    docx_image_policy,
     docx_comment_policy,
-    pdf_signature_policy,
+    docx_image_policy,
     docx_table_policy,
+    pdf_signature_policy,
     pdf_synth_mode_policy,
 )
 from tonic_textual.classes.httpclient import HttpClient
@@ -64,6 +75,9 @@ class DatasetFile:
     pdf_synth_mode_policy: Optional[pdf_synth_mode_policy] = None
         The policy for which version of PDF synthesis to use.  Options are V1 and V2.
     """
+
+    _TRANSIENT_DOWNLOAD_STATUS_CODES = frozenset({429, 502, 503, 504})
+    _MAX_RETRY_DELAY_SECONDS = 60
 
     def __init__(
         self,
@@ -136,8 +150,8 @@ class DatasetFile:
 
         num_retries: int = 6
             An optional value to specify the number of times to attempt to download the
-            file. If a file is not yet ready for download, there is a 10-second
-            pause before retrying. (The default value is 6)
+            file. Files that are not ready and transient HTTP failures (429, 502, 503,
+            and 504) are retried. (The default value is 6)
 
         wait_between_retries: int = 10
             The number of seconds to wait between retry attempts.
@@ -147,8 +161,11 @@ class DatasetFile:
         bytes
             The redacted file as a byte array.
         """
-        retries = 1
-        while retries <= num_retries:
+        if num_retries < 1:
+            raise ValueError("num_retries must be at least 1")
+
+        last_error = None
+        for attempt in range(1, num_retries + 1):
             try:
                 if random_seed is not None:
                     additional_headers = {"textual-random-seed": str(random_seed)}
@@ -161,16 +178,57 @@ class DatasetFile:
                         session=session,
                     )
 
-            except FileNotReadyForDownload:
-                retries = retries + 1
-                if retries <= num_retries:
-                    sleep(wait_between_retries)
+            except FileNotReadyForDownload as error:
+                last_error = error
+            except requests.exceptions.HTTPError as error:
+                if not self._is_transient_download_error(error):
+                    raise
+                last_error = error
 
-        retryWord = "retry" if num_retries == 1 else "retries"
+            if attempt < num_retries:
+                sleep(self._retry_delay(last_error, attempt, wait_between_retries))
+
+        if isinstance(last_error, requests.exceptions.HTTPError):
+            raise last_error
+
+        retry_word = "retry" if num_retries == 1 else "retries"
         raise FileNotReadyForDownload(
-            f"After {num_retries} {retryWord}, the file is not yet ready to download. "
+            f"After {num_retries} {retry_word}, the file is not yet ready to download. "
             "This is likely due to a high service load. Try again later."
         )
+
+    # Report whether an HTTP failure is safe to retry without changing the request.
+    @classmethod
+    def _is_transient_download_error(cls, error: requests.exceptions.HTTPError) -> bool:
+        return (
+            error.response is not None
+            and error.response.status_code in cls._TRANSIENT_DOWNLOAD_STATUS_CODES
+        )
+
+    # Compute bounded exponential backoff while honoring a numeric Retry-After header.
+    @classmethod
+    def _retry_delay(
+        cls,
+        error: Exception,
+        attempt: int,
+        wait_between_retries: int,
+    ) -> float:
+        backoff = min(
+            max(wait_between_retries, 0) * (2 ** (attempt - 1)),
+            cls._MAX_RETRY_DELAY_SECONDS,
+        )
+        if not isinstance(error, requests.exceptions.HTTPError):
+            return backoff
+
+        response = error.response
+        if response is None:
+            return backoff
+
+        retry_after = response.headers.get("Retry-After")
+        try:
+            return max(backoff, float(retry_after))
+        except (TypeError, ValueError):
+            return backoff
 
 
     def get_entities(self, pii_types: Optional[List[Union[PiiType, str]]] = None) -> Dict[PiiType, List[NerRedactionApiModel]]:        

--- a/tonic_textual/classes/httpclient.py
+++ b/tonic_textual/classes/httpclient.py
@@ -1,15 +1,17 @@
-from typing import Optional, Dict, Union, List
-import requests
-import os
 import json
+import os
+from typing import Dict, List, Optional, Union
+
+import requests
 from urllib3.exceptions import InsecureRequestWarning
 
+from tonic_textual import __version__
 from tonic_textual.classes.tonic_exception import (
+    BadRequestDownloadFile,
     ErrorWhenDownloadFile,
     FileNotReadyForDownload,
     LicenseInvalid,
     ParseFileTimeoutException,
-    BadRequestDownloadFile,
     TextualServerBadRequest,
     TextualServerError,
 )
@@ -36,9 +38,17 @@ class HttpClient:
         self.base_url = base_url
         self.headers = {
             "Authorization": api_key,
-            "User-Agent": "tonic-textual-python-sdk",
+            "User-Agent": f"tonic-textual-python-sdk/{__version__}",
         }
         self.verify = verify
+
+    # Return a useful server error whether the response body is JSON, text, or HTML.
+    @staticmethod
+    def _error_payload(response: requests.Response):
+        try:
+            return response.json()
+        except ValueError:
+            return response.text.strip() or f"HTTP {response.status_code}"
 
     def http_get_file(
         self,
@@ -70,15 +80,20 @@ class HttpClient:
             if err.response.status_code == 409:
                 raise FileNotReadyForDownload("File not yet ready for download")
             if err.response.status_code == 400:
-                error_data = err.response.json()
+                error_data = self._error_payload(err.response)
                 message_key = "errorMessage"
-                if message_key in error_data:
-                    raise BadRequestDownloadFile(
-                        f"Error Message: {error_data[message_key]}", response=res
-                    )
+                message = (
+                    error_data.get(message_key, error_data)
+                    if isinstance(error_data, dict)
+                    else error_data
+                )
+                raise BadRequestDownloadFile(
+                    f"Error Message: {message}", response=res
+                )
             if err.response.status_code == 500:
-                error_data = err.response.json()
-                raise TextualServerError(error_data)
+                raise TextualServerError(
+                    self._error_payload(err.response), response=err.response
+                )
             raise err
 
         return res.content
@@ -141,8 +156,9 @@ class HttpClient:
             res.raise_for_status()
         except requests.exceptions.HTTPError as err:
             if err.response.status_code == 500:
-                error_data = err.response.json()
-                raise TextualServerError(error_data)
+                raise TextualServerError(
+                    self._error_payload(err.response), response=err.response
+                )
             raise err
 
         return res.json()
@@ -200,8 +216,9 @@ class HttpClient:
             if err.response.status_code == 422:
                 raise LicenseInvalid(err)
             if err.response.status_code == 500:
-                error_data = err.response.json()
-                raise TextualServerError(error_data)
+                raise TextualServerError(
+                    self._error_payload(err.response), response=err.response
+                )
             if err.response.status_code == 400:
                 error_message = ''
                 try:
@@ -252,8 +269,9 @@ class HttpClient:
             if err.response.status_code == 422:
                 raise LicenseInvalid(err)
             if err.response.status_code == 500:
-                error_data = err.response.json()
-                raise TextualServerError(error_data)
+                raise TextualServerError(
+                    self._error_payload(err.response), response=err.response
+                )
             raise err
 
         return res.json()
@@ -267,8 +285,9 @@ class HttpClient:
             res.raise_for_status()
         except requests.exceptions.HTTPError as err:
             if err.response.status_code == 500:
-                error_data = err.response.json()
-                raise TextualServerError(error_data)
+                raise TextualServerError(
+                    self._error_payload(err.response), response=err.response
+                )
             raise err
 
         if res.content:
@@ -285,8 +304,9 @@ class HttpClient:
             res.raise_for_status()
         except requests.exceptions.HTTPError as err:
             if err.response.status_code == 500:
-                error_data = err.response.json()
-                raise TextualServerError(error_data)
+                raise TextualServerError(
+                    self._error_payload(err.response), response=err.response
+                )
             raise err
 
         if res.content:

--- a/tonic_textual/classes/httpclient.py
+++ b/tonic_textual/classes/httpclient.py
@@ -38,7 +38,8 @@ class HttpClient:
         self.base_url = base_url
         self.headers = {
             "Authorization": api_key,
-            "User-Agent": f"tonic-textual-python-sdk/{__version__}",
+            "User-Agent": "tonic-textual-python-sdk",
+            "X-Tonic-Textual-SDK-Version": __version__,
         }
         self.verify = verify
 

--- a/tonic_textual/classes/tonic_exception.py
+++ b/tonic_textual/classes/tonic_exception.py
@@ -1,4 +1,6 @@
-from typing import Dict
+from typing import Any, Optional
+
+import requests
 from requests.exceptions import HTTPError, RequestException
 
 
@@ -157,9 +159,23 @@ class TextualServerError(Exception):
     Raised when the Textual server responds with a 500.
     """
 
-    def __init__(self, error_payload: Dict):
-        msg = error_payload["error"]
+    def __init__(
+        self,
+        error_payload: Any,
+        response: Optional[requests.Response] = None,
+    ):
+        if isinstance(error_payload, dict):
+            msg = (
+                error_payload.get("error")
+                or error_payload.get("errorMessage")
+                or str(error_payload)
+            )
+        else:
+            msg = str(error_payload)
         super().__init__(msg)
+        self.error_payload = error_payload
+        self.response = response
+
 
 class TextualServerBadRequest(RequestException):
     """


### PR DESCRIPTION
## Description

Makes Python SDK file downloads recover from temporary Textual capacity and gateway failures without masking permanent PDF-processing errors. The SDK still performs one HTTP request per `DatasetFile.download` call and does not create download parallelism.

## Implemented

- Retry HTTP 429, 502, 503, and 504 responses with bounded exponential backoff and finite, nonnegative, 60-second-capped `Retry-After` support.
- Preserve the final HTTP error after the retry budget, while leaving permanent HTTP 500 failures non-retryable.
- Parse JSON, text, and HTML server errors without raising `JSONDecodeError`.
- Preserve the compatible `User-Agent` used by Solar attribution and report the SDK version in `X-Tonic-Textual-SDK-Version`.
- Keep existing 409 file-readiness polling at its fixed interval; only upstream capacity and gateway failures use exponential backoff.
- Add focused synthetic tests for retries, delays, exhausted retries, permanent failures, bounded headers, and non-JSON errors.
- Pin CI Ruff to the repository's declared development version and Python 3.9 compatibility target so external linter drift cannot invalidate the existing codebase.

## Related

- Solar API/PDF/admission fix: https://github.com/TonicAI/solar/pull/3456
- Jira: https://tonic-ai.atlassian.net/browse/TN-57737
