### PR TITLE
feat: expose Graph render batch API

### DIFF
--- a/tests/tests/subject_graph_tests/test_render_batch.py
+++ b/tests/tests/subject_graph_tests/test_render_batch.py
@@ -1,0 +1,100 @@
+import pytest
+
+from tonic_textual.classes.subject_graph_collection import (
+    MAX_RENDER_BATCH_ITEMS,
+    MAX_RENDER_BATCH_UTF16_CODE_UNITS,
+    SubjectGraph,
+)
+from tonic_textual.classes.tonic_exception import GraphRenderBatchError
+
+
+class _Response:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.content = b"{}"
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _Client:
+    def __init__(self, response):
+        self.response = response
+        self.call = None
+
+    def http_post_raw(self, url, data=None, additional_headers=None, timeout_seconds=None):
+        self.call = (url, data, additional_headers, timeout_seconds)
+        return self.response
+
+
+def _success_payload(items):
+    return {
+        "items": [
+            {
+                "documentId": item["documentId"],
+                "statusCode": 200,
+                "result": {"documentId": item["documentId"], "synthetic": item["text"].upper()},
+                "error": None,
+            }
+            for item in items
+        ]
+    }
+
+
+def test_render_documents_batch_posts_seeded_items_and_preserves_response_order():
+    requested = [
+        {"documentId": "doc-a", "text": "Alice"},
+        {"documentId": "doc-b", "text": "Bob"},
+    ]
+    response = _Response(200, _success_payload(list(reversed(requested))))
+    client = _Client(response)
+    graph = SubjectGraph(client, id="graph-id")
+
+    result = graph.render_documents_batch(requested, random_seed=42, timeout_seconds=17)
+
+    assert [item["documentId"] for item in result["items"]] == ["doc-a", "doc-b"]
+    assert client.call[0] == "/api/graph/graph-id/documents/render-batch"
+    assert client.call[1] == {"items": [
+        {"documentId": "doc-a", "text": "Alice", "seed": 42},
+        {"documentId": "doc-b", "text": "Bob", "seed": 42},
+    ]}
+    assert client.call[2] == {"textual-random-seed": "42"}
+    assert client.call[3] == 17
+
+
+def test_render_documents_batch_validates_limits_and_seed_consistency():
+    client = _Client(_Response(200, {"items": []}))
+    graph = SubjectGraph(client, id="graph-id")
+
+    with pytest.raises(ValueError, match="maximum is 500"):
+        graph.render_documents_batch([
+            {"documentId": str(index), "text": "x"}
+            for index in range(MAX_RENDER_BATCH_ITEMS + 1)
+        ])
+
+    large = "😀" * (MAX_RENDER_BATCH_UTF16_CODE_UNITS // 2 + 1)
+    with pytest.raises(ValueError, match="UTF-16 code units"):
+        graph.render_documents_batch([{ "documentId": "large", "text": large }])
+
+    with pytest.raises(ValueError, match="item seed must match"):
+        graph.render_documents_batch([
+            {"documentId": "doc-a", "text": "a", "seed": 1},
+        ], random_seed=2)
+
+
+def test_render_documents_batch_preserves_request_level_conflict_response():
+    response = _Response(409, {
+        "code": "projection_conflict",
+        "message": "render projection is stale",
+    })
+    client = _Client(response)
+    graph = SubjectGraph(client, id="graph-id")
+
+    with pytest.raises(GraphRenderBatchError) as exc_info:
+        graph.render_documents_batch([{ "documentId": "doc-a", "text": "a" }])
+
+    assert exc_info.value.response is response
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.code == "projection_conflict"

--- a/tonic_textual/classes/httpclient.py
+++ b/tonic_textual/classes/httpclient.py
@@ -68,7 +68,9 @@ class HttpClient:
             res.raise_for_status()
         except requests.exceptions.HTTPError as err:
             if err.response.status_code == 409:
-                raise FileNotReadyForDownload("File not yet ready for download")
+                raise FileNotReadyForDownload(
+                    "File not yet ready for download", response=err.response
+                )
             if err.response.status_code == 400:
                 error_data = err.response.json()
                 message_key = "errorMessage"
@@ -114,7 +116,9 @@ class HttpClient:
             if err.response.status_code == 422:
                 raise LicenseInvalid(err)
             if err.response.status_code == 409:
-                raise FileNotReadyForDownload("File not yet ready for download")
+                raise FileNotReadyForDownload(
+                    "File not yet ready for download", response=err.response
+                )
             if err.response.status_code == 500:
                 raise ErrorWhenDownloadFile(err)
             else:
@@ -226,6 +230,45 @@ class HttpClient:
                 return res.text
         else:
             return None
+
+    def http_post_raw(
+        self,
+        url,
+        params={},
+        data={},
+        files={},
+        additional_headers={},
+        timeout_seconds: Optional[int] = None,
+    ):
+        """Make a POST request and return the raw response without translating HTTP errors.
+
+        This is intentionally separate from :meth:`http_post`: a small number of newer APIs return
+        structured, per-item results or require callers to preserve the complete conflict response.
+        Existing SDK methods keep their historical exception mapping.
+        """
+        if (
+            timeout_seconds is None
+            and os.environ.get("TONIC_TEXTUAL_PARSE_TIMEOUT_IN_SECONDS") is not None
+        ):
+            try:
+                timeout_seconds = int(
+                    os.environ.get("TONIC_TEXTUAL_PARSE_TIMEOUT_IN_SECONDS")
+                )
+            except:  # noqa: E722
+                pass
+
+        try:
+            return requests.post(
+                self.base_url + url,
+                params=params,
+                json=data,
+                headers={**self.headers, **additional_headers},
+                verify=self.verify,
+                files=files,
+                timeout=timeout_seconds,
+            )
+        except requests.exceptions.Timeout:
+            raise ParseFileTimeoutException()
 
     def http_put(self, url, params={}, data={}, files={}):
         """Makes a put request.

--- a/tonic_textual/classes/subject_graph_collection.py
+++ b/tonic_textual/classes/subject_graph_collection.py
@@ -11,10 +11,46 @@ import requests
 
 from tonic_textual.classes.httpclient import HttpClient
 from tonic_textual.classes.subject_graph import CollectionSubjectGraph
+from tonic_textual.classes.tonic_exception import GraphRenderBatchError
 
 # Terminal reconcile / synthesize job states. Queued and Running are the only non-terminal
 # states, so anything else ends the wait loop (Completed is success; the rest are failures).
 _TERMINAL_JOB_STATES = {"Completed", "Failed", "Canceled", "Skipped"}
+MAX_RENDER_BATCH_ITEMS = 500
+MAX_RENDER_BATCH_UTF16_CODE_UNITS = 4_000_000
+
+
+def _utf16_code_units(value: str) -> int:
+    """Return the character count used by .NET ``string.Length``."""
+
+    return len(value.encode("utf-16-le", errors="surrogatepass")) // 2
+
+
+def _validate_render_seed(seed: Optional[int]) -> None:
+    if seed is None:
+        return
+    if type(seed) is not int or not -(2**31) <= seed <= 2**31 - 1:
+        raise ValueError("random_seed must be a signed 32-bit integer")
+
+
+def _response_error_code(response) -> Optional[str]:
+    try:
+        payload = response.json()
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    for key in ("code", "errorCode", "error_code", "type"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    error = payload.get("error")
+    if isinstance(error, dict):
+        for key in ("code", "errorCode", "error_code", "type"):
+            value = error.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
 
 
 class SubjectGraph:
@@ -497,6 +533,138 @@ class SubjectGraph:
         """
         response = self._render(document_id, text, random_seed)
         return response if isinstance(response, dict) else {"synthetic": response, "entities": []}
+
+    def render_documents_batch(
+        self,
+        items: List[dict],
+        random_seed: Optional[int] = None,
+        timeout_seconds: Optional[int] = None,
+    ) -> dict:
+        """Render multiple generic documents in one projection request.
+
+        ``items`` must contain dictionaries with ``documentId`` and ``text`` keys. The server may
+        return item-level failures inside an otherwise successful response; those are returned to the
+        caller unchanged. A request-level failure raises :class:`GraphRenderBatchError` and retains
+        the originating HTTP response for callers that need its structured conflict details.
+
+        The method deliberately sends one request, rather than splitting an arbitrary iterable. The
+        caller owns batching policy and can preserve its own document-to-output association while this
+        SDK method enforces the Graph request limits and wire contract.
+
+        Parameters
+        ----------
+        items : List[dict]
+            Generic render items in the desired association order. Each item has ``documentId`` and
+            exact original ``text``; an optional ``seed`` is accepted for compatibility with the API.
+        random_seed : Optional[int]
+            One seed for the request. When supplied, it is applied to every item and the request
+            header. Any item-level seed must match it.
+        timeout_seconds : Optional[int]
+            Optional HTTP request timeout.
+        """
+        if not isinstance(items, (list, tuple)):
+            raise TypeError("items must be a list or tuple")
+        if not items:
+            raise ValueError("items must not be empty")
+        if len(items) > MAX_RENDER_BATCH_ITEMS:
+            raise ValueError(
+                f"render batch contains {len(items)} items; maximum is {MAX_RENDER_BATCH_ITEMS}"
+            )
+
+        _validate_render_seed(random_seed)
+        normalized_items = []
+        item_seeds = []
+        total_units = 0
+        for index, item in enumerate(items):
+            if not isinstance(item, dict):
+                raise TypeError(f"render batch item {index} must be a dictionary")
+            document_id = item.get("documentId")
+            text = item.get("text")
+            if not isinstance(document_id, str) or not document_id.strip():
+                raise ValueError(f"render batch item {index} requires documentId")
+            if not isinstance(text, str):
+                raise ValueError(f"render batch item {index} requires text")
+
+            total_units += _utf16_code_units(text)
+            if total_units > MAX_RENDER_BATCH_UTF16_CODE_UNITS:
+                raise ValueError(
+                    "render batch exceeds the maximum of "
+                    f"{MAX_RENDER_BATCH_UTF16_CODE_UNITS} UTF-16 code units"
+                )
+
+            item_seed = item.get("seed")
+            if item_seed is not None:
+                _validate_render_seed(item_seed)
+                item_seeds.append(item_seed)
+            normalized = {"documentId": document_id, "text": text}
+            normalized_items.append(normalized)
+
+        if item_seeds and len(set(item_seeds)) != 1:
+            raise ValueError("all render batch item seeds must be identical")
+        if item_seeds and random_seed is not None and item_seeds[0] != random_seed:
+            raise ValueError("render batch item seed must match random_seed")
+        effective_seed = random_seed if random_seed is not None else (
+            item_seeds[0] if item_seeds else None
+        )
+        if effective_seed is not None:
+            for item in normalized_items:
+                item["seed"] = effective_seed
+
+        headers = (
+            {"textual-random-seed": str(effective_seed)}
+            if effective_seed is not None
+            else {}
+        )
+        response = self.client.http_post_raw(
+            f"/api/graph/{self.id}/documents/render-batch",
+            data={"items": normalized_items},
+            additional_headers=headers,
+            timeout_seconds=timeout_seconds,
+        )
+
+        if not 200 <= response.status_code < 300:
+            raise GraphRenderBatchError(
+                f"Graph render batch failed with HTTP {response.status_code}",
+                response=response,
+                code=_response_error_code(response),
+            )
+        try:
+            payload = response.json()
+        except (ValueError, TypeError) as exc:
+            raise GraphRenderBatchError(
+                "Graph render batch returned a non-JSON response", response=response
+            ) from exc
+        if not isinstance(payload, dict) or not isinstance(payload.get("items"), list):
+            raise GraphRenderBatchError(
+                "Graph render batch returned an invalid response shape", response=response
+            )
+
+        requested_ids = [item["documentId"] for item in normalized_items]
+        response_items = payload["items"]
+        by_id = {}
+        for index, item in enumerate(response_items):
+            if not isinstance(item, dict) or not isinstance(item.get("documentId"), str):
+                raise GraphRenderBatchError(
+                    f"Graph render batch item {index} has no documentId", response=response
+                )
+            document_id = item["documentId"]
+            if document_id in by_id:
+                raise GraphRenderBatchError(
+                    f"Graph render batch returned duplicate documentId {document_id!r}",
+                    response=response,
+                )
+            by_id[document_id] = item
+        if set(by_id) != set(requested_ids) or len(by_id) != len(requested_ids):
+            raise GraphRenderBatchError(
+                "Graph render batch response does not match the requested document ids",
+                response=response,
+            )
+
+        # The API promises request order, but normalizing here makes association deterministic even if
+        # a compatible server returns items in a different order.
+        normalized_payload = dict(payload)
+        normalized_payload["items"] = [by_id[document_id] for document_id in requested_ids]
+        return normalized_payload
 
     def render_pdf(
         self,

--- a/tonic_textual/classes/tonic_exception.py
+++ b/tonic_textual/classes/tonic_exception.py
@@ -73,8 +73,22 @@ class FileNotReadyForDownload(Exception):
     Raised when you make a request to download a file that is not yet ready for download
     """
 
-    def __init__(self, msg):
+    def __init__(self, msg, response=None):
         super().__init__(msg)
+        # Keep the originating response available to callers that need to distinguish a transient
+        # file-readiness conflict from a projection/source conflict. Existing callers only relied on
+        # the exception message, so this is backwards-compatible while preserving diagnostics.
+        self.response = response
+
+
+class GraphRenderBatchError(HTTPError):
+    """Raised when the graph render-batch request fails as a whole or is malformed."""
+
+    def __init__(self, msg, response=None, code=None):
+        super().__init__(msg, response=response)
+        self.response = response
+        self.code = code
+        self.status_code = getattr(response, "status_code", None)
 
 
 class AudioTranscriptionResultAlreadyRetrieved(Exception):


### PR DESCRIPTION
Add bounded batch rendering with shared seed validation and structured request-level errors while retaining HTTP responses for diagnostics.