### PR TITLE
Expose multiclass parent model metadata

### DIFF
--- a/tests/tests/redact_tests/test_model_based_entity_name.py
+++ b/tests/tests/redact_tests/test_model_based_entity_name.py
@@ -1,0 +1,112 @@
+import json
+
+import pytest
+
+from tonic_textual.classes.common_api_responses.replacement import Replacement
+from tonic_textual.generator_utils import replacement_to_grouping_entity
+from tonic_textual.redact_api import TextualNer
+
+
+ENTITY = {
+    "start": 0,
+    "end": 6,
+    "newStart": 0,
+    "newEnd": 18,
+    "label": "MEDICAL_HEIGHT",
+    "text": "six ft",
+    "newText": "[MEDICAL_HEIGHT]",
+    "score": 0.98,
+    "language": "en",
+    "modelBasedEntityName": "MEDICAL_MEASUREMENT",
+}
+
+
+def test_replacement_serializes_model_based_entity_name_when_present():
+    replacement = Replacement(
+        start=0,
+        end=6,
+        new_start=0,
+        new_end=18,
+        label="MEDICAL_HEIGHT",
+        text="six ft",
+        score=0.98,
+        language="en",
+        model_based_entity_name="MEDICAL_MEASUREMENT",
+    )
+
+    assert replacement.model_based_entity_name == "MEDICAL_MEASUREMENT"
+    assert replacement.to_dict()["model_based_entity_name"] == "MEDICAL_MEASUREMENT"
+    assert json.loads(json.dumps(replacement))["model_based_entity_name"] == "MEDICAL_MEASUREMENT"
+
+
+def test_replacement_omits_model_based_entity_name_when_absent():
+    replacement = Replacement(
+        start=0,
+        end=4,
+        new_start=0,
+        new_end=4,
+        label="NAME_GIVEN",
+        text="John",
+        score=0.95,
+        language="en",
+    )
+
+    assert replacement.model_based_entity_name is None
+    assert "model_based_entity_name" not in replacement.to_dict()
+    assert "model_based_entity_name" not in replacement
+
+
+@pytest.fixture
+def offline_ner(monkeypatch):
+    ner = TextualNer("http://localhost", api_key="fake-key")
+    responses = {
+        "/api/redact": {
+            "originalText": "six ft",
+            "redactedText": "[MEDICAL_HEIGHT]",
+            "usage": 2,
+            "deIdentifyResults": [ENTITY],
+        },
+        "/api/redact/bulk": {
+            "bulkText": ["six ft"],
+            "bulkRedactedText": ["[MEDICAL_HEIGHT]"],
+            "usage": 2,
+            "deIdentifyResults": [{**ENTITY, "idx": 0}],
+        },
+        "/api/synthesis/group": {
+            "groups": [{"representative": "six ft", "entities": [ENTITY]}],
+        },
+    }
+    monkeypatch.setattr(ner.client, "http_post", lambda url, **_: responses[url])
+    return ner
+
+
+def test_single_redaction_preserves_model_based_entity_name(offline_ner):
+    response = offline_ner.send_redact_request("/api/redact", {})
+
+    assert response.de_identify_results[0].model_based_entity_name == "MEDICAL_MEASUREMENT"
+
+
+def test_bulk_redaction_preserves_model_based_entity_name(offline_ner):
+    response = offline_ner.send_redact_bulk_request("/api/redact/bulk", {})
+
+    assert response.de_identify_results[0][0].model_based_entity_name == "MEDICAL_MEASUREMENT"
+
+
+def test_grouping_round_trip_preserves_model_based_entity_name(offline_ner):
+    replacement = Replacement(
+        start=0,
+        end=6,
+        new_start=0,
+        new_end=18,
+        label="MEDICAL_HEIGHT",
+        text="six ft",
+        score=0.98,
+        language="en",
+        model_based_entity_name="MEDICAL_MEASUREMENT",
+    )
+
+    payload_entity = replacement_to_grouping_entity(replacement, "six ft")
+    response = offline_ner.group_entities([replacement], "six ft")
+
+    assert payload_entity["modelBasedEntityName"] == "MEDICAL_MEASUREMENT"
+    assert response.groups[0].entities[0].model_based_entity_name == "MEDICAL_MEASUREMENT"

--- a/tonic_textual/classes/common_api_responses/replacement.py
+++ b/tonic_textual/classes/common_api_responses/replacement.py
@@ -37,6 +37,9 @@ class Replacement(dict):
     xml_path : Optional[str]
         The xpath of the entity in the original XML document. This is only present
         if the input text was an XML document. NOTE: Arrays in xpath are 1-based.
+    model_based_entity_name : Optional[str]
+        The parent model-based entity name when the detected label is a child label
+        emitted by a multiclass model.
     """
 
     def __init__(
@@ -53,6 +56,7 @@ class Replacement(dict):
         example_redaction: Optional[str] = None,
         json_path: Optional[str] = None,
         xml_path: Optional[str] = None,
+        model_based_entity_name: Optional[str] = None,
     ):
         self.start = start
         self.end = end
@@ -66,6 +70,7 @@ class Replacement(dict):
         self.example_redaction = example_redaction
         self.json_path = json_path
         self.xml_path = xml_path
+        self.model_based_entity_name = model_based_entity_name
 
         dict.__init__(
             self,
@@ -85,6 +90,11 @@ class Replacement(dict):
             ),
             **({} if json_path is None else {"json_path": json_path}),
             **({} if xml_path is None else {"xml_path": xml_path}),
+            **(
+                {}
+                if model_based_entity_name is None
+                else {"model_based_entity_name": model_based_entity_name}
+            ),
         )
 
     def describe(self) -> str:
@@ -109,4 +119,6 @@ class Replacement(dict):
             out["json_path"] = self.json_path
         if self.xml_path is not None:
             out["xml_path"] = self.xml_path
+        if self.model_based_entity_name is not None:
+            out["model_based_entity_name"] = self.model_based_entity_name
         return out

--- a/tonic_textual/generator_utils.py
+++ b/tonic_textual/generator_utils.py
@@ -488,7 +488,7 @@ def replacement_to_grouping_entity(replacement: Replacement, text: str) -> dict:
     csharp_start = replacement.start + offsets[replacement.start]
     csharp_end = replacement.end + offsets[replacement.end - 1]
     
-    return {
+    entity = {
         "start": csharp_start,             # C# UTF-16 index
         "end": csharp_end,                 # C# UTF-16 index
         "pythonStart": replacement.start,  # Python index
@@ -501,3 +501,6 @@ def replacement_to_grouping_entity(replacement: Replacement, text: str) -> dict:
         "head": None,
         "tail": None
     }
+    if replacement.model_based_entity_name is not None:
+        entity["modelBasedEntityName"] = replacement.model_based_entity_name
+    return entity

--- a/tonic_textual/redact_api.py
+++ b/tonic_textual/redact_api.py
@@ -661,7 +661,8 @@ class TextualNer:
                     score=entity_data.get("score"),
                     language=entity_data.get("language"),
                     new_text=entity_data.get("newText"),
-                    example_redaction=entity_data.get("exampleRedaction")
+                    example_redaction=entity_data.get("exampleRedaction"),
+                    model_based_entity_name=entity_data.get("modelBasedEntityName"),
                 ))
             
             groups.append(
@@ -1040,6 +1041,7 @@ class TextualNer:
                 example_redaction=result.get("exampleRedaction"),
                 json_path=result.get("jsonPath"),
                 xml_path=result.get("xmlPath"),
+                model_based_entity_name=result.get("modelBasedEntityName"),
             )
             for result in response["deIdentifyResults"]
         ]
@@ -1087,6 +1089,7 @@ class TextualNer:
                     score=result["score"],
                     language=result.get("language"),
                     example_redaction=result.get("exampleRedaction"),
+                    model_based_entity_name=result.get("modelBasedEntityName"),
                 )
             )
 


### PR DESCRIPTION
## Summary

- expose optional `model_based_entity_name` on SDK `Replacement` objects
- preserve Solar response `modelBasedEntityName` metadata for single, bulk, and grouping responses
- include the parent-model metadata when serializing replacements and grouping payloads

This complements Solar PR #3495’s multiclass LoRA support. It is optional parent-model metadata exposure for SDK consumers; existing responses and replacement serialization remain unchanged when the metadata is absent.

## Tests

- `poetry run ruff check .`
- `poetry run pytest -q tests/tests/redact_tests/test_model_based_entity_name.py tests/tests/grouping_tests/test_grouping_serializable.py`
- `poetry run pytest -q tests/tests/grouping_tests tests/tests/csv_helper`